### PR TITLE
add the missing shadow_type field for hpmcounter17 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1] - 2021-11-19
+
+### Added
+
+- adding the missing shadow_type field for hpmcounter17
+
 ## [2.11.0] - 2021-10-15
 ### Fixed
   - canonical ordering requirement of `_Z` extensions fixed
@@ -16,8 +22,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [2.10.1] - 2021-08-26
 ### Fixed
    - Changed the default value of 'accessible' to false so input yamls need not declare unsupported xlen
-   
-   
+
+
 ## [2.10.0] - 2021-07-30
 ### Added
    - added default-setters for misa's reset value to match the ISA extensions, to modify warl function of extensions under misa
@@ -28,7 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
    - changed default values of types for fflags, frm and fcsr to warl if F is present, else read-only constant 0
    - changed default values of types for mcycle[h], minstret[h] to  warl
    - changed default values of types and added checks for subfields of scause, satp, stvec, sie, sip and sstatus
-   
+
 ## [2.9.1] - 2021-06-02
 ### Fixed
 - removed an unadded feature in rv32i_platform.yaml

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '2.11.0'
+__version__ = '2.11.1'

--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -6028,6 +6028,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter17, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}


### PR DESCRIPTION
When I wrote a python script to parse the yaml generated by riscv-config, I found All other hpmcounter* have shadow_type field except for hpmcounter17 .