### PR TITLE
bump to 2.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.1] - 2021-12-18
+### Fixed
+
+  - added mbe and sbe fields in mstatush
+  - fixed default setter for vsstatus in RV32 mode
+
 ## [2.12.0] - 2021-12-10
 
 ### Added

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '2.12.0'
+__version__ = '2.12.1'

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -53,8 +53,6 @@ def reset_vsstatus():
     global inp_yaml
     if 64 in inp_yaml['supported_xlen'] and 'U' in inp_yaml['ISA']:
       return 8589934592
-    elif 32 in inp_yaml['supported_xlen'] and 'U' in inp_yaml['ISA']:
-      return 42949672960
     else:	
       return 0
 

--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -1446,6 +1446,42 @@ hart_schema:
                   default: {ro_constant: 0}
               default: {implemented: false}
               check_with: h_check
+            mbe:
+              type: dict
+              schema:
+                description: { type: string, default: control the endianness of memory accesses other than instruction fetches for machine mode}
+                shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
+                msb: {type: integer, default: 5, allowed: [5]}
+                lsb: {type: integer, default: 5, allowed: [5]}
+                implemented: {type: boolean, default: true}
+                type:
+                  type: dict
+                  check_with: wr_illegal
+                  oneof:
+                  - schema: { warl: *ref_warl }
+                  - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
+                  - schema: { wlrl: *ref_wlrl }
+                  default: {ro_constant: 0}
+              default: {implemented: false}
+            sbe:
+              type: dict
+              schema:
+                description: { type: string, default: control the endianness of memory accesses other than instruction fetches for supervisor mode}
+                shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
+                msb: {type: integer, default: 4, allowed: [4]}
+                lsb: {type: integer, default: 4, allowed: [4]}
+                implemented: {type: boolean, default: true}
+                type:
+                  type: dict
+                  check_with: wr_illegal
+                  oneof:
+                  - schema: { warl: *ref_warl }
+                  - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
+                  - schema: { wlrl: *ref_wlrl }
+                  default: {ro_constant: 0}
+              default: {implemented: false}
             accessible:
               type: boolean
               default: false


### PR DESCRIPTION

  - added mbe and sbe fields in mstatush
  - fixed default setter for vsstatus in RV32 mode
