### PR TITLE
warl improvement and other changes (bump to 3.0.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
           
       - name: Run rv32i
         run: riscv-config -ispec examples/rv32i_isa.yaml
+      
+      - name: Run rv64i
+        run: riscv-config -ispec examples/rv64i_isa.yaml
 
   check-version:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2022-08-16
+
+  - created new warl class for warl node handling
+
+    - better comments
+    - more functions to keep things simple
+    - fixed a lot of bugs in checking legal values
+    - bitmask and range values can now co-exist in a legal string
+    - added new and improved checks for syntax validity of warl strings
+
+  - fixed validationError function to correctly print all errors (dict and/or list)
+  - removed wr\_illegal checks from the schema since they are now done as part of the new warl class
+    checks
+  - updates to the new warl checks and reset-value checks
+  - satp.mode should have one of sv\* translation schemes as a legal value. (#89)
+  - default setters for pmps fixed
+  - pmp checks have been improved (#88)
+  - improve WARL documentation
+
 ## [2.17.0] - 2022-08-08
 
   - Support for Zfinx, Zdinx, Zfh, Zhinx, Zhinxmin in ISA string added.

--- a/docs/source/code-doc.rst
+++ b/docs/source/code-doc.rst
@@ -28,3 +28,11 @@ Utils
    :members: 
    :special-members:
    :private-members:
+
+WARL
+----
+
+.. automodule:: riscv_config.warl_new
+   :members:
+   :special-members:
+   :private-members:

--- a/docs/source/yaml-specs.rst
+++ b/docs/source/yaml-specs.rst
@@ -28,7 +28,7 @@ CSRs with sub-fields
 
   <name>:                                   # name of the csr
     description: <text>                     # textual description of the csr
-    address: <hex>                          # address of the CSR
+    address: <hex>                          # address of the csr
     priv_mode: <D/M/H/S/U>                  # privilege mode that owns the register
     reset-val: <hex>                        # Reset value of the register. This an accumulation 
                                             # of the all reset values of the sub-fields 
@@ -80,7 +80,7 @@ CSRs without sub-fields
 
   <name>:                                 # name of the csr
     description: <text>                   # textual description of the csr
-    address: <hex>                        # address of the CSR
+    address: <hex>                        # address of the csr
     priv_mode: <D/M/H/S/U>                # privilege mode that owns the register
     reset-val: <hex>                      # Reset value of the register. This an accumulation 
                                           # of the all reset values of the sub-fields 
@@ -115,25 +115,25 @@ CSRs without sub-fields
 Constraints
 -----------
 
-Each CSR undergoes the following checks:
+Each csr undergoes the following checks:
 
   1. All implemented fields at the csr-level, if set to True, are checked if
      they comply with the supported_xlen field of the ISA yaml.
   2. The reset-val is checked against compliance with the type field specified
      by the user. All unimplemented fields are considered to be hardwired to 0.
 
-For each of the above templates the following fields for all standard CSRs
+For each of the above templates the following fields for all standard csrs
 defined by the spec are frozen and **CANNOT** be modified by the user.
 
-* description
-* address
-* priv_mode
-* fields
-* shadow
-* msb
-* lsb
-* The type field for certain CSRs (like readonly) is also constrained.
-* fields names also cannot be modified for standard CSRs
+  * description
+  * address
+  * priv_mode
+  * fields
+  * shadow
+  * msb
+  * lsb
+  * The type field for certain csrs (like readonly) is also constrained.
+  * fields names also cannot be modified for standard csrs
 
 Only the following fields can be modified by the user:
 
@@ -163,8 +163,8 @@ Following is an example of how a user can define the mtvec csr in the input ISA 
             - "mode[1:0] in [1] -> base[29:6] in [0x000000:0xF00000] base[5:0] in [0x00]" # 256 byte aligned values only in vectored mode.
           wr_illegal:
             - "mode[1:0] in [0] -> Unchanged"
-            - "mode[1:0] in [1] and wr_val in [0x2000000:0x4000000] -> 0x2000000"
-            - "mode[1:0] in [1] and wr_val in [0x4000001:0x3FFFFFFF] -> Unchanged"
+            - "mode[1:0] in [1] && writeval in [0x2000000:0x4000000] -> 0x2000000"
+            - "mode[1:0] in [1] && writeval in [0x4000001:0x3FFFFFFF] -> Unchanged"
     mode:
       implemented: true
       type:                             
@@ -191,14 +191,14 @@ above user-input:
           implemented: true
           type:
             warl:
-              dependency_fields: [mtvec::mode]
+              dependency_fields: [mtvec::mode, writeval]
               legal:
               - 'mode[1:0] in [0] -> base[29:0] in [0x20000000, 0x20004000]'               # can take only 2 fixed values in direct mode.
               - 'mode[1:0] in [1] -> base[29:6] in [0x000000:0xF00000] base[5:0] in [0x00]'   # 256 byte aligned values only in vectored mode.
               wr_illegal:
               - 'mode[1:0] in [0] -> Unchanged'
-              - 'mode[1:0] in [1] and wr_val in [0x2000000:0x4000000] -> 0x2000000'
-              - 'mode[1:0] in [1] and wr_val in [0x4000001:0x3FFFFFFF] -> Unchanged'
+              - 'mode[1:0] in [1] && writeval in [0x2000000:0x4000000] -> 0x2000000'
+              - 'mode[1:0] in [1] && writeval in [0x4000001:0x3FFFFFFF] -> Unchanged'
           description: Vector base address.
           shadow: none
           msb: 31
@@ -226,27 +226,34 @@ above user-input:
 WARL field Definition
 =====================
 
-Since the RISC-V privilege spec indicates several CSRs and sub-fields of CSRs to be WARL (Write-Any-Read-Legal), 
+Since the RISC-V privilege spec indicates several csrs and sub-fields of csrs to be WARL (Write-Any-Read-Legal), 
 it is necessary to provide a common scheme of representation which can precisely 
-define the functionality of any such WARL field/register. 
+define the functionality of any such WARL field/register.
 
 
 Value Descriptors
 -----------------
 
-This is a list which describes a set of values. Each entry can either represent a single distinct value or a range of values. 
+Value descriptors are standard syntaxes that are used to define values in any
+part of the WARL string. The 2 basic descriptors are : distinct-values and
+range-values as described below:
 
-* **distinct-values** - This specifies that only the particular value should be added to the set.
-    
-  .. code-block:: python
+  * **distinct-values** - This specifies that only the particular value should be added to the set.
       
-    val
-    
-* **range** - This specifies that all the values greater than or equal to lower and less than or equal to upper is to be included in the set.
-       
-  .. code-block:: python
-       
-    lower:upper
+    .. code-block:: python
+        
+      val
+      
+  * **range** - This specifies that all the values greater than or equal to lower and less than or equal to upper is to be included in the set.
+         
+    .. code-block:: python
+         
+      lower:upper
+
+For any variable in the WARL string, the values can an amalgamation of
+distinct-values and/or range-values. They are typically captured in a list as
+shown in the below examples:
+
     
 Example:
      
@@ -258,124 +265,177 @@ Example:
   # To represent the set {5, 10, 31}
     [5, 10, 31]
 
-  # To represent the set {2, 3, 4, 5, 10}
-    [2:5, 10]
+  # To represent the set {2, 3, 4, 5, 10, 11, 12, 13, 50}
+    [2:5, 10:13, 50]
       
 WARL Node definition
 --------------------
 
-A WARL csr/field has the following skeleton in the riscv-config:
+A typical WARL node (used for a WARL csr or subfield) has the following skeleton 
+in the riscv-config:
 
 .. code-block:: yaml
 
-   WARL:   
-      dependency_fields: [list]
-      legal: [list of warl-string]
-      wr_illegal: [list of warl-string]
+   warl:   
+      dependency_fields: [list of csrs/subfields that legal values depend on]
+      legal: [list of strings adhering to the warl-syntax for legal assignments]
+      wr_illegal: [list of strings ahdering to the warl-syntax for illegal assignments]
 
-- **dependency_fields** : A list of other csrs/fields whose values define the set of legal values the 
-  csr/field under question can take. We use ``::`` as a hierarchy separator. This field can be empty as well indicating 
-  no other state affects this csr/field. The fields within csrs can be specified as follows:
+- **dependency_fields** : This is a list of csrs/subfields whose values affect
+  the legal values of the csr under question. ``::`` is used as a hierarchy
+  separator to indicate subfields. This list can be empty to indicate that the
+  csr under question is not affected by any other architectural state. The
+  ordering of the csr/subfields has no consequence. Examples of the list are 
+  provided below:
 
   ..  code-block:: yaml
 
       - dependency_fields: [mtvec::mode]
       - dependency_fields: [misa::mxl, mepc]
-    
+  
+  The following keywords are reserved and can be used accordingly in the
+  dependency_fields list: 
 
-- **legal** : This field takes in a list of strings which define the WARL functions. Each string needs to adhere to the
-  following syntax:
+    - ``writeval`` : to represent dependency on the current value being written 
+      to the csr/subfield
+    - ``currval`` : to represent dependency on the value of the csr/subfield
+      before performing the write operation
+
+  **Restrictions imposed**: The following restrictions are imposed on the
+  elements of the list:
+
+    1. The csrs/subfields mentioned in the list must have their 
+       accessible/implemented fields set to True in the isa yaml.
+
+- **legal** : This field is a list of strings which define the warl functions of
+  the csr/subfield. Each string needs to adhere to the following warl-syntax:
+
+  .. code-block::
+
+     dependency_string -> legal_value_string
+
+  The ``dependency_string`` substring is basically a string defining a boolean 
+  condition based on the dependent csrs (those listed in the
+  ``dependency_fields``). Only when the boolean condition is satisfied, the
+  corresponding warl function defined in ``legal_value_string`` substring is
+  evaluated. A write only occurs when the evaluation of the
+  ``legal_value_string`` also is True. The symbol ``->`` is used to denote 
+  `implies` and is primarily used to split the string in to the above two 
+  substrings. If none of the entries in the list evaluate to True, then the
+  current write value is considered illegal and the actions defined by the
+  `wr_illegal` field is carried out.
+
+  The substrings ``dependency_string ->`` is optional. If the ``dependency_fields`` list is
+  empty, then the substring ``dependency_string ->`` must be omitted from the warl string.
+
+  The ``dependency_string`` and the ``legal_value_string`` both follow the same
+  legal syntax:
+
+  .. code-block::
+
+     <variable-name>[<hi-index>:<lo-index>] <op> <value-descriptors>
+
+  The ``variable-name`` field can be the name a csr or a subfield (without the
+  hierarchical delimiter ``::``). Within the ``dependency_string`` substring the variable
+  names can only be those listed in the ``dependency_fields`` list. In the
+  ``legal_value_string`` substring however, the ``variable-name`` should be
+  either `writeval` or the name the csr or the subfield (without the
+  hierarchical delimiter ``::``) that the warl node belongs to.
+
+  The indices fields ``hi-index`` and ``lo-index`` are used to indicate the bit
+  range of the variable that being looked-up or modified. The basic constraints
+  are that ``hi-index`` must be greater than the ``lo-index``. If only a
+  single-bit is being looked-up/assigned, then ``:lo-index`` can be skipped.
+  This definition applies to both the ``dependency_string`` and the
+  ``legal_value_string``.
+
+  The ``op`` field in the ``dependency_string`` substring can be one of ``in``
+  or ``not in`` to indicate that the variable takes the values defined in the
+  ``value-descriptors`` field or does not take those values respectively. In
+  addition to the above operators, the ``legal_value_string`` can include one
+  more operator : ``bitmask``. When using the ``bitmask`` operator the
+  value-descriptors have to be a list of two distinct-values as follows:
 
   .. code-block:: yaml
 
-    - [dependency-vals] -> field-name[index-hi:index-lo] in [legal-values]
-    - [dependency-vals] -> field-name[index-hi:index-lo] bitmask [mask, fixedval]
-    
-    # if no dependency_fields exists then following is also allowed:
-    
-    field-name[index-hi:index-lo] bitmask [mask, fixedval]
-    
-  In short it means that under certain values of the dependency_fields the warl-field can take only the legal values 
-  defined by either `[legal-values]` or by the `bitmask` function. 
-  
-  - **dependency-vals** : A comma separated list of value-descriptors indicating the values the corresponding fields in the
-    dependency_fields take. 
+     csr_name[hi:lo] bitmask [mask, fixedval]
 
-  - **->**: represents "imply".
-  
-  - **field-name**: should be the same as the csr/field-name for which this WARL function is being described.
-  
-  - **index-**: These are unsigned integers not exceeding the size of field. Sometimes it easier to define the WARL 
-    function by splitting the fields. Thus the following is also a legal form:
-    
-    .. code-block:: yaml
-    
-      [dependency-vals] -> field-name[index-hi:index-lo] in [legal-values1] & field-name[index-lo-1:0] in [legal-values2]
-    
-  - **in**: key-word indicating that `field-name[index-hi:index-lo]` should takes values defined within `[legal_values]`.
+  Both the ``mask`` and ``fixedval`` fields are integers. All bits set in the
+  mask indicates writable bits of the variable. All bits bits cleared in the
+  mask indicate bits with a constant value which is derived from the
+  corresponding bit in the fixedval field.
 
-  - **bitmask**: keyword indicating that the legal values are defined using a mask and fixedval variables. The fixedval variable defines the default value of the masked bits.
-
-  - **legal-values**: a list of value-descriptors indicating the set of legal values `field-name[index-hi:index-lo]` can 
-    take.
-    
-    **Restrictions**:
-    
-    1. No legal value must exceed the maximum value which can be supported (based on the width of the field). 
-    2. Functions should be exhaustive with respect to every possible combination of the dependency values.
-    3. within a string for `legal` all bits of the csr/field should be covered. No bits must be left undefined.
-    4. A legal string should be a combination of ranges split into parts or a simple bitmask function for the entire field. Mixing bitmask and ranges is not allowed. The following example is an invalid spec:
-
-    .. code-block:: yaml
-
-      [0] -> field[31:6] in [0x10000000: 0x3FFFFFF] & field[5:0] bitmask [0x30, 0x0F]
-  
-  
-- **wr_illegal** : This field takes in a list of strings which define the next legal value of the field when an illegal
-  value is written. Each string needs to adhere to the following syntax:
+  Since the ``dependency_string`` is supposed to represent a boolean condition,
+  it also has the flexibility to use basic boolean operators like ``&&`` and
+  ``||`` around the above legal syntax. Examples are provided below:
 
   .. code-block:: yaml
 
-      [dependency-vals] wr_val in [illegal-values] -> update_mode
-                          OR
-      [dependency-vals] -> update_mode
+     (csrA[2:0] in [0, 1]) && (csrB[5:0] in [0:25] || csrB[5:0] in [31,30]) ->
 
-  In short this means that under certain values of the dependency_fields when an illegal write happens (either defined by 
-  the wr_val or for all illegal values) the next legal value is defined by the `update_mode`.
-
-  - **dependency-vals** : A comma separated list of value-descriptors indicating the values the corresponding fields in the
-    dependency_fields take. 
     
-  - **wr_val**: key-word indicating the illegal write-value
-
-  - **in**: same meaning as the before.
+  **Restrictions imposed**: The following restrictions are imposed on the above
+  substrings:
   
-  - **illegal-values**: a list of value-descriptors indicating the set of illegal values for the csr/field under question.
-  
-  - **update_mode** : This field dictates what the next legal read value is when an illegal write happens:
+    1. No element of the value-descriptors must exceed the maximum value which 
+       can be supported by the indices of the csr/subfield. 
+    2. The csrs/subfields used in the ``dependency_string`` must be in those
+       listed in the ``dependency_fields`` list.
+    3. Valid operators in the ``dependency_string`` substring are ``in`` and ``not in``.
+    4. Valid operators in the ``legal_value_string`` substring are ``in``, ``not in`` and ``bitmask``
+    5. Within the ``legal_value_string`` substrings the legal values of all bits 
+       of the csr/subfield must be specified. No bits must be left undefined.
+    6. If the ``dependency_fields`` is empty, then only one legal string must be
+       defined in this list. 
+    7. The first combination of the ``dependency_string`` and ``legal_value_string`` 
+       to evaluate to True, starting from the top of the list is given highest
+       priority to define the next legal value of the csr/subfield.
+    8. The reset-value of the csr/subfield must cause atleast one of the legal
+       strings in the list to evaluate to True.
 
-      - **unchanged**: The value remains unchanged to the current legal value.
+  **Assumptions**
+
+    1. Since the list of all ``dependency_string`` substrings is not required to 
+       be exhaustively defined
+       by the user, if none of the ``dependency_strings`` in the list evaluate to
+       true, then the current write operation should be treated as an illegal
+       write operation, and the action defined by the ``wr_illegal`` node must be
+       carried out.
+    2. If one of the dependent csrs/subfield defined in the
+       ``dependency_fields`` is not used in the ``dependency_strings``, then it
+       implictly assumed that, the variable does not affect the legal value for
+       that string
+
+- **wr_illegal** : This field takes in a list of strings which define the next 
+  legal value of the field when an illegal value is being written to the 
+  csr/subfield. Each string needs to adhere to the following syntax:
+
+  .. code-block:: yaml
+
+      dependency_string -> update_mode
+
+  The ``dependency_string`` follows the same rules, assumptions and restrictions
+  described above. When the ``dependency_string`` evaluates to True the
+  ``update_mode`` substring defines the next legal value of the csr/subfield.
+  The supported values of the ``update_mode`` string are :
+
+      - **Unchanged**: The value remains unchanged to the current legal value held in the csr/subfield.
       - **<val>**: A single value can also be specified
-      - **nextup**: ceiling(*wr_val*) i.e. the next larger or the largest element of the legal list
-      - **nextdown**: floor(*wr_val*) i.e. the next smallest or the smallest element of the legal list
-      - **nearup**: celing(*wr_val*) i.e. the closest element in the list, with the larger element being chosen in case of a tie.
-      - **neardown**: floor(*wr_val*) i.e. the closes element in the list, with the smaller element being chosen in case of a tie
-      - **max**: maximum of all legal values
-      - **min**: minimum of all legal values
-      - **addr**: 
+      - **Nextup**: ceiling(*writeval*) i.e. the next larger or the largest element of the legal list
+      - **Nextdown**: floor(*writeval*) i.e. the next smallest or the smallest element of the legal list
+      - **Nearup**: celing(*writeval*) i.e. the closest element in the list, with the larger element being chosen in case of a tie.
+      - **Neardown**: floor(*writeval*) i.e. the closes element in the list, with the smaller element being chosen in case of a tie
+      - **Max**: maximum of all legal values
+      - **Min**: minimum of all legal values
+      - **Addr**: 
 
         .. code-block:: python
 
           if ( val < base || val > bound)
               return Flip-MSB of field
 
-    **Restrictions**:
-      
-      1. wr_illegal will not exists for a legal list defined as a bitmask.
-
-
-
-Example:
+Examples
+--------
   
 .. code-block:: yaml
 
@@ -383,21 +443,22 @@ Example:
     WARL: 
       dependency_fields: [mtvec::mode]
       legal:
-        - "[0] -> base[29:0] in [0x20000000, 0x20004000]"  # can take only 2 fixed values when mode==0.
-        - "[1] -> base[29:6] in [0x000000:0xF00000] base[5:0] in [0x00]" # 256 byte aligned when mode==1
+        - "mode[1:0] in [0] -> base[29:0] in [0x20000000, 0x20004000]"  # can take only 2 fixed values when mode==0.
+        - "mode[1:0] in [1] -> base[29:6] in [0x000000:0xF00000] base[5:0] in [0x00]" # 256 byte aligned when mode==1
       wr_illegal:
-        - "[0] -> unchanged"
-        - "[1] wr_val in [0x2000000:0x4000000] -> 0x2000000" # predefined value if write value is
-        - "[1] wr_val in [0x4000001:0x3FFFFFFF] -> unchanged"
+        - "mode[1:0] in [0] -> unchanged"
+        - "mode[1:0] in [1] && writeval in [0x2000000:0x4000000] -> 0x2000000" # predefined value if write value is
+        - "mode[1:0] in [1] && writeval in [0x4000001:0x3FFFFFFF] -> unchanged"
 
     # When base of mtvec depends on the mode field. Using bitmask instead of range
     WARL: 
       dependency_fields: [mtvec::mode]
       legal:
-        - "[0] -> base[29:0] in [0x20000000, 0x20004000]"  # can take only 2 fixed values when mode==0.
-        - "[1] -> base[29:0] bitmask [0x3FFFFFC0, 0x00000000]" # 256 byte aligned when mode==1
+        - "mode[1:0] in [0] -> base[29:0] in [0x20000000, 0x20004000]"  # can take only 2 fixed values when mode==0.
+        - "mode[1:0] in [1] -> base[29:0] bitmask [0x3FFFFFC0, 0x00000000]" # 256 byte aligned when mode==1
       wr_illegal:
-        - "[0] -> unchanged" # no illegal for bitmask defined legal strings.
+        - "mode[1:0] in [0] -> unchanged" # no illegal for bitmask defined legal strings.
+        - Unchanged
         
 
     # no dependencies. Mode field of mtvec can take only 2 legal values using range-descriptor

--- a/examples/rv32i_isa_checked.yaml
+++ b/examples/rv32i_isa_checked.yaml
@@ -5780,12 +5780,14 @@ hart0:
         rv32:
             accessible: true
             fields:
+              - sbe
+              - mbe
               - gva
               - mpv
               -
                   -
                       - 0
-                      - 5
+                      - 3
                   -
                       - 8
                       - 31
@@ -5805,6 +5807,22 @@ hart0:
                 msb: 6
                 lsb: 6
                 type: {ro_constant: 0}
+            mbe:
+                implemented: false
+                description: control the endianness of memory accesses other than
+                    instruction fetches for machine mode
+                shadow:
+                shadow_type: rw
+                msb: 5
+                lsb: 5
+            sbe:
+                implemented: false
+                description: control the endianness of memory accesses other than
+                    instruction fetches for supervisor mode
+                shadow:
+                shadow_type: rw
+                msb: 4
+                lsb: 4
         rv64:
             accessible: false
         description: The mstatush register keeps track of and controls the hart’s
@@ -7104,7 +7122,7 @@ hart0:
                     warl:
                         dependency_fields: []
                         legal:
-                          - asid[0] in [0x0,0x1]
+                          - mode[0] in [0x0,0x1]
                         wr_illegal:
                           - Unchanged
         rv64:

--- a/examples/rv64i_isa.yaml
+++ b/examples/rv64i_isa.yaml
@@ -47,10 +47,10 @@ hart0:
                 warl:
                     dependency_fields: []
                     legal:
-                      - "sepc[63:0] bitmask [0xFFFFFFFFFFFFFFFE, 0x0000000000000000]"
+                      - "sepc[63:60] in [1,2] spec[59:0] not in [1,2]"
                     wr_illegal:
                       - "Unchanged"
-        reset-val: 0
+        reset-val: 0x2000000000000000
     stval:
         rv32:
             accessible: false
@@ -230,13 +230,59 @@ hart0:
                       wr_illegal:
                         - Unchanged
             pmp4cfg:
-                implemented: false
+                implemented: true
+                type:
+                  ro_constant: 0
             pmp5cfg:
-                implemented: false
+                implemented: true
+                type:
+                  ro_constant: 0
             pmp6cfg:
-                implemented: false
+                implemented: true
+                type:
+                  ro_constant: 0
             pmp7cfg:
-                implemented: false
+                implemented: true
+                type:
+                  ro_constant: 0
+    pmpcfg2:
+        reset-val: 0
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            pmp8cfg:
+                implemented: true
+                type:
+                  ro_constant: 0
+            pmp9cfg:
+                implemented: true
+                type:
+                  ro_constant: 0
+            pmp10cfg:
+                implemented: true
+                type:
+                  ro_constant: 0
+            pmp11cfg:
+                implemented: true
+                type:
+                  ro_constant: 0
+            pmp12cfg:
+                implemented: true
+                type:
+                  ro_constant: 0
+            pmp13cfg:
+                implemented: true
+                type:
+                  ro_constant: 0
+            pmp14cfg:
+                implemented: true
+                type:
+                  ro_constant: 0
+            pmp15cfg:
+                implemented: true
+                type:
+                  ro_constant: 0
     pmpaddr0:
         rv32:
             accessible: false
@@ -289,6 +335,35 @@ hart0:
                     wr_illegal:
                       - Unchanged
         reset-val: 0
+    pmpaddr4: &pmp_const
+        rv32:
+          accessible: False
+        rv64:
+          accessible: True
+          type:
+            ro_constant : 0
+    pmpaddr5: 
+      <<: *pmp_const
+    pmpaddr6: 
+      <<: *pmp_const
+    pmpaddr7: 
+      <<: *pmp_const
+    pmpaddr8: 
+      <<: *pmp_const
+    pmpaddr9: 
+      <<: *pmp_const
+    pmpaddr10: 
+      <<: *pmp_const
+    pmpaddr11: 
+      <<: *pmp_const
+    pmpaddr12: 
+      <<: *pmp_const
+    pmpaddr13: 
+      <<: *pmp_const
+    pmpaddr14: 
+      <<: *pmp_const
+    pmpaddr15: 
+      <<: *pmp_const
     mhpmcounter3:
         rv32:
             accessible: false

--- a/examples/rv64i_isa_checked.yaml
+++ b/examples/rv64i_isa_checked.yaml
@@ -61,7 +61,7 @@ hart0:
                 warl:
                     dependency_fields: []
                     legal:
-                      - sepc[63:0] bitmask [0xFFFFFFFFFFFFFFFE, 0x0000000000000000]
+                      - sepc[63:60] in [1,2] spec[59:0] not in [1,2]
                     wr_illegal:
                       - Unchanged
             fields: []
@@ -69,7 +69,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-        reset-val: 0
+        reset-val: 0x2000000000000000
         description: The sepc is a warl register that must be able to hold all valid
             physical and virtual addresses.
         address: 0x141
@@ -417,28 +417,36 @@ hart0:
                 msb: 31
                 lsb: 24
             pmp4cfg:
-                implemented: false
+                implemented: true
+                type:
+                    ro_constant: 0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
                 msb: 39
                 lsb: 32
             pmp5cfg:
-                implemented: false
+                implemented: true
+                type:
+                    ro_constant: 0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
                 msb: 47
                 lsb: 40
             pmp6cfg:
-                implemented: false
+                implemented: true
+                type:
+                    ro_constant: 0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
                 msb: 55
                 lsb: 48
             pmp7cfg:
-                implemented: false
+                implemented: true
+                type:
+                    ro_constant: 0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -455,6 +463,96 @@ hart0:
               - pmp7cfg
         description: PMP configuration register
         address: 0x3A0
+        priv_mode: M
+    pmpcfg2:
+        reset-val: 0
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            pmp8cfg:
+                implemented: true
+                type:
+                    ro_constant: 0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 7
+                lsb: 0
+            pmp9cfg:
+                implemented: true
+                type:
+                    ro_constant: 0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 15
+                lsb: 8
+            pmp10cfg:
+                implemented: true
+                type:
+                    ro_constant: 0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 23
+                lsb: 16
+            pmp11cfg:
+                implemented: true
+                type:
+                    ro_constant: 0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 31
+                lsb: 24
+            pmp12cfg:
+                implemented: true
+                type:
+                    ro_constant: 0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 39
+                lsb: 32
+            pmp13cfg:
+                implemented: true
+                type:
+                    ro_constant: 0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 47
+                lsb: 40
+            pmp14cfg:
+                implemented: true
+                type:
+                    ro_constant: 0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 55
+                lsb: 48
+            pmp15cfg:
+                implemented: true
+                type:
+                    ro_constant: 0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 63
+                lsb: 56
+            fields:
+              - pmp8cfg
+              - pmp9cfg
+              - pmp10cfg
+              - pmp11cfg
+              - pmp12cfg
+              - pmp13cfg
+              - pmp14cfg
+              - pmp15cfg
+        description: PMP configuration register
+        address: 0x3A2
         priv_mode: M
     pmpaddr0:
         rv32:
@@ -540,6 +638,187 @@ hart0:
         description: Physical memory protection address register
         address: 0x3B3
         priv_mode: M
+    pmpaddr4:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: &id001
+                ro_constant: 0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 63
+            lsb: 0
+        description: Physical memory protection address register
+        address: 0x3B4
+        priv_mode: M
+        reset-val: 0
+    pmpaddr5:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: *id001
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 63
+            lsb: 0
+        description: Physical memory protection address register
+        address: 0x3B5
+        priv_mode: M
+        reset-val: 0
+    pmpaddr6:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: *id001
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 63
+            lsb: 0
+        description: Physical memory protection address register
+        address: 0x3B6
+        priv_mode: M
+        reset-val: 0
+    pmpaddr7:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: *id001
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 63
+            lsb: 0
+        description: Physical memory protection address register
+        address: 0x3B7
+        priv_mode: M
+        reset-val: 0
+    pmpaddr8:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: *id001
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 63
+            lsb: 0
+        description: Physical memory protection address register
+        address: 0x3B8
+        priv_mode: M
+        reset-val: 0
+    pmpaddr9:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: *id001
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 63
+            lsb: 0
+        description: Physical memory protection address register
+        address: 0x3B9
+        priv_mode: M
+        reset-val: 0
+    pmpaddr10:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: *id001
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 63
+            lsb: 0
+        description: Physical memory protection address register
+        address: 0x3BA
+        priv_mode: M
+        reset-val: 0
+    pmpaddr11:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: *id001
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 63
+            lsb: 0
+        description: Physical memory protection address register
+        address: 0x3BB
+        priv_mode: M
+        reset-val: 0
+    pmpaddr12:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: *id001
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 63
+            lsb: 0
+        description: Physical memory protection address register
+        address: 0x3BC
+        priv_mode: M
+        reset-val: 0
+    pmpaddr13:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: *id001
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 63
+            lsb: 0
+        description: Physical memory protection address register
+        address: 0x3BD
+        priv_mode: M
+        reset-val: 0
+    pmpaddr14:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: *id001
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 63
+            lsb: 0
+        description: Physical memory protection address register
+        address: 0x3BE
+        priv_mode: M
+        reset-val: 0
+    pmpaddr15:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: *id001
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 63
+            lsb: 0
+        description: Physical memory protection address register
+        address: 0x3BF
+        priv_mode: M
+        reset-val: 0
     mhpmcounter3:
         rv32:
             accessible: false
@@ -1498,15 +1777,6 @@ hart0:
         address: 0x3A1
         priv_mode: M
         reset-val: 0
-    pmpcfg2:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: false
-        description: PMP configuration register
-        address: 0x3A2
-        priv_mode: M
-        reset-val: 0
     pmpcfg3:
         rv32:
             accessible: false
@@ -1622,114 +1892,6 @@ hart0:
             accessible: false
         description: PMP configuration register
         address: 0x3AF
-        priv_mode: M
-        reset-val: 0
-    pmpaddr4:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: false
-        description: Physical memory protection address register
-        address: 0x3B4
-        priv_mode: M
-        reset-val: 0
-    pmpaddr5:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: false
-        description: Physical memory protection address register
-        address: 0x3B5
-        priv_mode: M
-        reset-val: 0
-    pmpaddr6:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: false
-        description: Physical memory protection address register
-        address: 0x3B6
-        priv_mode: M
-        reset-val: 0
-    pmpaddr7:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: false
-        description: Physical memory protection address register
-        address: 0x3B7
-        priv_mode: M
-        reset-val: 0
-    pmpaddr8:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: false
-        description: Physical memory protection address register
-        address: 0x3B8
-        priv_mode: M
-        reset-val: 0
-    pmpaddr9:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: false
-        description: Physical memory protection address register
-        address: 0x3B9
-        priv_mode: M
-        reset-val: 0
-    pmpaddr10:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: false
-        description: Physical memory protection address register
-        address: 0x3BA
-        priv_mode: M
-        reset-val: 0
-    pmpaddr11:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: false
-        description: Physical memory protection address register
-        address: 0x3BB
-        priv_mode: M
-        reset-val: 0
-    pmpaddr12:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: false
-        description: Physical memory protection address register
-        address: 0x3BC
-        priv_mode: M
-        reset-val: 0
-    pmpaddr13:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: false
-        description: Physical memory protection address register
-        address: 0x3BD
-        priv_mode: M
-        reset-val: 0
-    pmpaddr14:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: false
-        description: Physical memory protection address register
-        address: 0x3BE
-        priv_mode: M
-        reset-val: 0
-    pmpaddr15:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: false
-        description: Physical memory protection address register
-        address: 0x3BF
         priv_mode: M
         reset-val: 0
     pmpaddr16:
@@ -2245,7 +2407,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: &id001
+            type: &id002
                 ro_constant: 0
         description: The mhpmevent5 is a MXLEN-bit event register which controls mhpmcounter5.
         address: 0x325
@@ -2261,7 +2423,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter5 is a 64-bit counter. Returns lower 52 bits in
             RV52I mode.
         address: 0xB05
@@ -2286,7 +2448,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent6 is a MXLEN-bit event register which controls mhpmcounter6.
         address: 0x326
         priv_mode: M
@@ -2301,7 +2463,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter6 is a 64-bit counter. Returns lower 62 bits in
             RV62I mode.
         address: 0xB06
@@ -2326,7 +2488,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent7 is a MXLEN-bit event register which controls mhpmcounter7.
         address: 0x327
         priv_mode: M
@@ -2341,7 +2503,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter7 is a 64-bit counter. Returns lower 72 bits in
             RV72I mode.
         address: 0xB07
@@ -2366,7 +2528,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent8 is a MXLEN-bit event register which controls mhpmcounter8.
         address: 0x328
         priv_mode: M
@@ -2381,7 +2543,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter8 is a 64-bit counter. Returns lower 82 bits in
             RV82I mode.
         address: 0xB08
@@ -2406,7 +2568,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent9 is a MXLEN-bit event register which controls mhpmcounter9.
         address: 0x329
         priv_mode: M
@@ -2421,7 +2583,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter9 is a 64-bit counter. Returns lower 32 bits in
             RV32I mode.
         address: 0xB09
@@ -2446,7 +2608,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent10 is a MXLEN-bit event register which controls
             mhpmcounter10.
         address: 0x32a
@@ -2462,7 +2624,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter10 is a 64-bit counter. Returns lower 102 bits
             in RV102I mode.
         address: 0xB0A
@@ -2487,7 +2649,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent11 is a MXLEN-bit event register which controls
             mhpmcounter11.
         address: 0x32b
@@ -2503,7 +2665,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter11 is a 64-bit counter. Returns lower 112 bits
             in RV112I mode.
         address: 0xB0B
@@ -2528,7 +2690,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent12 is a MXLEN-bit event register which controls
             mhpmcounter12.
         address: 0x32c
@@ -2544,7 +2706,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter12 is a 64-bit counter. Returns lower 122 bits
             in RV122I mode.
         address: 0xB0C
@@ -2569,7 +2731,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent13 is a MXLEN-bit event register which controls
             mhpmcounter13.
         address: 0x32d
@@ -2585,7 +2747,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter13 is a 64-bit counter. Returns lower 132 bits
             in RV132I mode.
         address: 0xB0D
@@ -2610,7 +2772,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent14 is a MXLEN-bit event register which controls
             mhpmcounter14.
         address: 0x32e
@@ -2626,7 +2788,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter14 is a 64-bit counter. Returns lower 142 bits
             in RV142I mode.
         address: 0xB0E
@@ -2651,7 +2813,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent15 is a MXLEN-bit event register which controls
             mhpmcounter15.
         address: 0x32f
@@ -2667,7 +2829,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter15 is a 64-bit counter. Returns lower 152 bits
             in RV152I mode.
         address: 0xB0F
@@ -2692,7 +2854,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent16 is a MXLEN-bit event register which controls
             mhpmcounter16.
         address: 0x330
@@ -2708,7 +2870,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter16 is a 64-bit counter. Returns lower 162 bits
             in RV162I mode.
         address: 0xB10
@@ -2733,7 +2895,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent17 is a MXLEN-bit event register which controls
             mhpmcounter17.
         address: 0x331
@@ -2749,7 +2911,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter17 is a 64-bit counter. Returns lower 172 bits
             in RV172I mode.
         address: 0xB11
@@ -2774,7 +2936,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent18 is a MXLEN-bit event register which controls
             mhpmcounter18.
         address: 0x332
@@ -2790,7 +2952,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter18 is a 64-bit counter. Returns lower 182 bits
             in RV182I mode.
         address: 0xB12
@@ -2815,7 +2977,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent19 is a MXLEN-bit event register which controls
             mhpmcounter19.
         address: 0x333
@@ -2831,7 +2993,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter19 is a 64-bit counter. Returns lower 32 bits
             in RV32I mode.
         address: 0xB13
@@ -2856,7 +3018,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent20 is a MXLEN-bit event register which controls
             mhpmcounter20.
         address: 0x334
@@ -2872,7 +3034,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter20 is a 64-bit counter. Returns lower 202 bits
             in RV202I mode.
         address: 0xB14
@@ -2897,7 +3059,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent21 is a MXLEN-bit event register which controls
             mhpmcounter21.
         address: 0x335
@@ -2913,7 +3075,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter21 is a 64-bit counter. Returns lower 212 bits
             in RV212I mode.
         address: 0xB15
@@ -2938,7 +3100,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent22 is a MXLEN-bit event register which controls
             mhpmcounter22.
         address: 0x336
@@ -2954,7 +3116,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter22 is a 64-bit counter. Returns lower 222 bits
             in RV222I mode.
         address: 0xB16
@@ -2979,7 +3141,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent23 is a MXLEN-bit event register which controls
             mhpmcounter23.
         address: 0x337
@@ -2995,7 +3157,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter23 is a 64-bit counter. Returns lower 232 bits
             in RV232I mode.
         address: 0xB17
@@ -3020,7 +3182,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent24 is a MXLEN-bit event register which controls
             mhpmcounter24.
         address: 0x338
@@ -3036,7 +3198,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter24 is a 64-bit counter. Returns lower 242 bits
             in RV242I mode.
         address: 0xB18
@@ -3061,7 +3223,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent25 is a MXLEN-bit event register which controls
             mhpmcounter25.
         address: 0x339
@@ -3077,7 +3239,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter25 is a 64-bit counter. Returns lower 252 bits
             in RV252I mode.
         address: 0xB19
@@ -3102,7 +3264,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent26 is a MXLEN-bit event register which controls
             mhpmcounter26.
         address: 0x33a
@@ -3118,7 +3280,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter26 is a 64-bit counter. Returns lower 262 bits
             in RV262I mode.
         address: 0xB1A
@@ -3143,7 +3305,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent27 is a MXLEN-bit event register which controls
             mhpmcounter27.
         address: 0x33b
@@ -3159,7 +3321,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter27 is a 64-bit counter. Returns lower 272 bits
             in RV272I mode.
         address: 0xB1B
@@ -3184,7 +3346,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent28 is a MXLEN-bit event register which controls
             mhpmcounter28.
         address: 0x33c
@@ -3200,7 +3362,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter28 is a 64-bit counter. Returns lower 282 bits
             in RV282I mode.
         address: 0xB1C
@@ -3225,7 +3387,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent29 is a MXLEN-bit event register which controls
             mhpmcounter29.
         address: 0x33d
@@ -3241,7 +3403,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter29 is a 64-bit counter. Returns lower 32 bits
             in RV32I mode.
         address: 0xB1D
@@ -3266,7 +3428,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent30 is a MXLEN-bit event register which controls
             mhpmcounter30.
         address: 0x33e
@@ -3282,7 +3444,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter30 is a 64-bit counter. Returns lower 302 bits
             in RV302I mode.
         address: 0xB1E
@@ -3307,7 +3469,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmevent31 is a MXLEN-bit event register which controls
             mhpmcounter31.
         address: 0x33f
@@ -3323,7 +3485,7 @@ hart0:
             shadow_type: rw
             msb: 63
             lsb: 0
-            type: *id001
+            type: *id002
         description: The mhpmcounter31 is a 64-bit counter. Returns lower 312 bits
             in RV312I mode.
         address: 0xB1F

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '2.17.0'
+__version__ = '3.0.0'

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -1314,7 +1314,7 @@ def check_warl_legality(spec, logging = False):
                     err = warl_inst.iserr()
             elif fields != []:
                 for f in fields:
-                    if not isinstance(f, list):
+                    if not isinstance(f, list) and node[f]['implemented']:
                         if node[f]['shadow'] is None and 'warl' in node[f]['type']:
                             if logging:
                                 logger.debug(f'Checking legality of warl strings for : {csrname}.{f}')

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -10,7 +10,7 @@ import riscv_config.utils as utils
 from riscv_config.errors import ValidationError
 from riscv_config.schemaValidator import schemaValidator
 import riscv_config.constants as constants
-from riscv_config.warl import warl_interpreter
+from riscv_config.warl import warl_class
 
 logger = logging.getLogger(__name__)
 
@@ -1305,197 +1305,144 @@ def check_pmp(spec, logging = False):
         if error:
             errors[csrname] = error
     return errors
-   
 
+def check_warl_legality(spec, logging = False):
+    errors = {}
+    for csrname, csrnode in spec.items():
+        fields = []
+        err = []
+        if isinstance(csrnode, dict) and 'priv_mode' in csrnode:
+            if csrnode['rv64']['accessible']:
+                fields = get_fields(csrnode['rv64'], 64)
+                node = csrnode['rv64']
+            elif csrnode['rv32']['accessible']:
+                fields = get_fields(csrnode['rv32'], 32)
+                node = csrnode['rv32']
+            else:
+                continue
+            if fields == [] and node['shadow'] is None:
+                if 'warl' in node['type']:
+                    if logging:
+                        logger.debug(f'Checking legality of warl strings for csr: {csrname}')
+                    warl_inst = warl_class(node['type']['warl'], csrname, node['msb'], node['lsb'], spec)
+                    err = warl_inst.iserr()
+            elif fields != []:
+                for f in fields:
+                    if not isinstance(f, list):
+                        if node[f]['shadow'] is None and 'warl' in node[f]['type']:
+                            if logging:
+                                logger.debug(f'Checking legality of warl strings for : {csrname}.{f}')
+                            warl_inst = warl_class(node[f]['type']['warl'], f'{csrname}::{f}', node[f]['msb'], node[f]['lsb'], spec)
+                            err_f = warl_inst.iserr()
+                            if err_f:
+                                err.append(err_f)
+        if err:
+            errors[csrname] = err
 
-
+    return spec, errors
+                
 
 
 def check_reset_fill_fields(spec, logging= False):
     '''The check_reset_fill_fields function fills the field node with the names of the sub-fields of the register and then checks whether the reset-value of the register is a legal value. To do so, it iterates over all the subfields and extracts the corresponding field value from the reset-value. Then it checks the legality of the value according to the given field description. If the fields is implemented i.e accessible in both 64 bit and 32 bit modes, the 64 bit mode is given preference. '''
     errors = {}
-    for node in spec:
+    for csrname, csrnode in spec.items():
 
-        if isinstance(spec[node], dict):
+        if isinstance(csrnode, dict) and 'priv_mode' in csrnode:
+            if csrnode['rv32']['accessible']:
+                csrnode['rv32']['fields'] = get_fields(
+                    csrnode['rv32'], 32)
+            if csrnode['rv64']['accessible']:
+                csrnode['rv64']['fields'] = get_fields(
+                    csrnode['rv64'], 64)
+
+            csr_reset_val = csrnode['reset-val']
+            if csrnode['rv64']['accessible']:
+                csrnode = csrnode['rv64']
+            elif csrnode['rv32']['accessible']:
+                csrnode = csrnode['rv32']
+            else:
+                continue
             if logging:
-                logger.debug('Checking Reset fields for: ' +  node)
-            if spec[node]['rv32']['accessible']:
-                spec[node]['rv32']['fields'] = get_fields(
-                    spec[node]['rv32'], 32)
-            if spec[node]['rv64']['accessible']:
-                spec[node]['rv64']['fields'] = get_fields(
-                    spec[node]['rv64'], 64)
-            if 'reset-val' in spec[node].keys():
-                reset_val = spec[node]['reset-val']
-                if spec[node]['rv64']['accessible']:
-                    field_desc = spec[node]['rv64']
-                    bit_len = 64
-                elif spec[node]['rv32']['accessible']:
-                    field_desc = spec[node]['rv32']
-                    bit_len = 32
-                else:
-                    continue
-                error = []
-                if not field_desc['fields']:
-                    if field_desc['shadow'] is None:
-                        desc = field_desc['type']
-                        keys = desc.keys()
-                        if 'wlrl' in keys:
-                            res = False
-                            for entry in desc['wlrl']:
-                                if ":" in entry:
-                                    low, high = entry.split(":")
-                                    if "x" in low:
-                                        low = int(low, base=16)
-                                        high = int(high, base=16)
-                                    else:
-                                        low = int(low)
-                                        high = int(high)
-                                    if reset_val >= low and reset_val <= high:
-                                        res = True
-                                        break
-                                else:
-                                    if "x" in entry:
-                                        val = int(entry, base=16)
-                                    else:
-                                        val = int(entry)
-                                    if val == reset_val:
-                                        res = True
-                                        break
-                            if not res:
-                                error.append(
-                                    "Reset value doesnt match the 'wlrl' description for the register."
-                                )
-                        elif 'ro_constant' in keys:
-                            if reset_val != desc['ro_constant']:
-                                error.append(
-                                    "Reset value doesnt match the 'ro_constant' description for the register."
-                                )
-                        elif 'ro_variable' in keys:
-                            pass
-                        elif "warl" in keys:
-                            warl = (warl_interpreter(desc['warl']))
-                            deps = warl.dependencies
-                            dep_vals = []
-                            for dep in deps:
-                                reg = dep.split("::")
-                                if len(reg) == 1:
-                                    dep_vals.append(spec[reg[0]]['reset-val'])
-                                else:
-                                    bin_str = bin(spec[reg[0]]
-                                                  ['reset-val'])[2:].zfill(bit_len)
-                                    msb = spec[reg[0]]['rv{}'.format(bit_len)][reg[1]]['msb']
-                                    lsb = spec[reg[0]]['rv{}'.format(bit_len)][reg[1]]['lsb']
-                                    dep_vals.append(
-                                        int(bin_str[::-1][lsb:msb+1][::-1], base=2))
-                            if (warl.islegal(int(reset_val), dep_vals) != True):
-                                error.append(
-                                    "Reset value doesnt match the 'warl' description for the register."
-                                )
-                else:
-                    bin_str = bin(reset_val)[2:].zfill(bit_len)
-                    for field in field_desc['fields']:
-                        if isinstance(field, list):
-                            for entry in field:
-                                if len(entry) == 2:
-                                    test_val = int(
-                                        bin_str[bit_len - 1 - entry[1]:bit_len -
-                                                entry[0]],
-                                        base=2)
-                                    if test_val != 0:
-                                        error.append("WPRI bits " +
-                                                     str(entry[0]) + " to " +
-                                                     str(entry[1]) +
-                                                     " should be zero.")
-                                elif len(entry) == 1:
-                                    test_val = int(bin_str[bit_len - 1 -
-                                                           entry[0]],
-                                                   base=2)
-                                    if test_val != 0:
-                                        error.append("WPRI bit " +
-                                                     str(entry[0]) +
-                                                     " should be zero.")
-                        else:
-                            test_val = int(
-                                bin_str[bit_len - 1 -
-                                        field_desc[field]['msb']:bit_len -
-                                        field_desc[field]['lsb']],
-                                base=2)
-                            if field_desc[field]['implemented']:
-                                if field_desc[field]['shadow'] is None:
-                                    logger.debug('--> Subfield: ' + field)
-                                    desc = field_desc[field]['type']
-                                    keys = desc.keys()
-                                    if 'wlrl' in keys:
-                                        res = False
-                                        for entry in desc['wlrl']:
-                                            if ":" in entry:
-                                                low, high = entry.split(":")
-                                                if "x" in low:
-                                                    low = int(low, base=16)
-                                                    high = int(high, base=16)
-                                                else:
-                                                    low = int(low)
-                                                    high = int(high)
-                                                if test_val >= low and test_val <= high:
-                                                    res = True
-                                                    break
-                                            else:
-                                                if "x" in entry:
-                                                    val = int(entry, base=16)
-                                                else:
-                                                    val = int(entry)
-                                                if val == test_val:
-                                                    res = True
-                                                    break
-                                        if not res:
-                                            error.append(
-                                                "Reset value for " + field +
-                                                " doesnt match the 'wlrl' description."
-                                            )
-                                    elif 'ro_constant' in keys:
-                                        if test_val != desc['ro_constant']:
-                                            error.append(
-                                                "Reset value for " + field +
-                                                " doesnt match the 'ro_constant' description."
-                                            )
-                                    elif 'ro_variable' in keys:
-                                        pass
-                                    elif "warl" in keys:
-                                        warl = (warl_interpreter(desc['warl']))
-                                        deps = warl.dependencies
-                                        dep_vals = []
-                                        for dep in deps:
-                                            reg = dep.split("::")
-                                            if len(reg) == 1:
-                                                dep_vals.append(
-                                                    spec[reg[0]]['reset-val'])
-                                            else:
-                                                bin_str = bin(
-                                                    spec[reg[0]]['reset-val']
-                                                )[2:].zfill(bit_len)
-                                                dep_vals.append(
-                                                    int(bin_str[
-                                                        bit_len - 1 -
-                                                        spec[reg[0]]['rv{}'.format(
-                                                            bit_len
-                                                        )][reg[1]]['msb']:bit_len -
-                                                        spec[reg[0]]['rv{}'.format(
-                                                            bit_len
-                                                        )][reg[1]]['lsb']],
-                                                        base=2))
-                                        if (warl.islegal(
-                                                int(test_val), dep_vals) !=
-                                                True):
-                                            error.append(
-                                                "Reset value for " + field +
-                                                " doesnt match the 'warl' description."
-                                            )
-                            elif test_val != 0:
-                                error.append("Reset value for unimplemented " +
-                                             field + " cannot be non zero.")
-                if error:
-                    errors[node] = error
+                logger.debug(f'Checking Reset fields for: {csrname}')
+            error = []
+            if not csrnode['fields'] and csrnode['shadow'] is None:
+                csrtype = csrnode['type']
+                if 'wlrl' in csrtype:
+                    wlrl_atleast_one_pass = False
+                    for entry in csrtype['wlrl']:
+                        if ":" in entry:
+                            [low, high] = [ int(x,0) for x in entry.split(":")]
+                            if csr_reset_val >= low and csr_reset_val <= high:
+                                wlrl_atleast_one_pass = True
+                                break
+                            elif csr_reset_val == int(entry, 0):
+                                wlrl_atleast_one_pass = True
+                                break
+                    if not wlrl_atleast_one_pass:
+                        error.append("Reset value:{hex(csr_reset_val)} \
+doesn't match the 'wlrl' description :{csrtype['wlrl']} for the register.")
+                elif 'ro_constant' in csrtype:
+                    if csr_reset_val != csrtype['ro_constant']:
+                        error.append("Reset value doesnt match the \
+'ro_constant' description for the register.")
+                elif 'ro_variable' in csrtype:
+                    pass
+                elif "warl" in csrtype:
+                    warl_inst = warl_class(csrnode['type']['warl'], f'{csrname}', csrnode['msb'], csrnode['lsb'], spec)
+                    legal_err = warl_inst.islegal(csr_reset_val)
+                    if legal_err != []:
+                        logger.error('f{legal_err}')
+                        error.append( " Reset value doesn't match the 'warl' description for the register.")
+                        error = error + legal_err
+            elif csrnode['fields']:
+                for field in csrnode['fields']:
+                    if isinstance(field, list):
+                        for entry in field:
+                            low = entry[0]
+                            high = entry[-1]
+                            bitlen = high - low + 1
+                            test_val = (csr_reset_val >> low) & ((1<<bitlen)-1)
+                            if test_val != 0:
+                                error.append(f'WPRI bits [{high}:{low}] should \
+be zero')
+                    else:
+                        submsb = csrnode[field]['msb']
+                        sublsb = csrnode[field]['lsb']
+                        subbitlen = submsb - sublsb + 1
+                        test_val = (csr_reset_val >> sublsb) & ((1<<subbitlen)-1)
+                        if csrnode[field]['implemented'] and csrnode[field]['shadow'] is None:
+                            logger.debug(' --> Subfield: '+field)
+                            csrtype = csrnode[field]['type']
+                            if 'wlrl' in csrtype:
+                                wlrl_atleast_one_pass = False
+                                for entry in csrtype['wlrl']:
+                                    if ":" in entry:
+                                        [low, high] = [ int(x,0) for x in entry.split(":")]
+                                        if test_val >= low and test_val <= high:
+                                            wlrl_atleast_one_pass = True
+                                            break
+                                        elif test_val == int(entry, 0):
+                                            wlrl_atleast_one_pass = True
+                                            break
+                                if not wlrl_atleast_one_pass:
+                                    error.append("Reset value:{hex(csr_reset_val)} \
+doesn't match the 'wlrl' description :{csrtype['wlrl']} for the subfield: {field}.")
+                            elif 'ro_constant' in csrtype:
+                                if test_val != csrtype['ro_constant']:
+                                    error.append("Reset value doesnt match the \
+'ro_constant' description for the subfield: {field}.")
+                            elif 'ro_variable' in csrtype:
+                                pass
+                            elif "warl" in csrtype:
+                                warl_inst = warl_class(csrnode[field]['type']['warl'], f'{csrname}::{field}', submsb, sublsb, spec)
+                                legal_err = warl_inst.islegal(test_val)
+                                if legal_err != []:
+                                    logger.error('f{legal_err}')
+                                    error.append( " Reset value doesn't match the 'warl' description for the register.")
+                                    error = error + legal_err
+            if error:
+                errors[csrname] = error
     return spec, errors
 
 def check_debug_specs(debug_spec, isa_spec,
@@ -1577,11 +1524,21 @@ def check_debug_specs(debug_spec, isa_spec,
         else:
             error_list = validator.errors
             raise ValidationError("Error in " + foo + ".", error_list)
+
+        normalized['ISA'] = isa_string
+
+        if logging:
+            logger.info("Initiating WARL legality checks.")
+        normalized, errors = check_warl_legality(normalized, logging)
+        if errors:
+            raise ValidationError("Error in " + foo + ".", errors)
+
         if logging:
             logger.info("Initiating post processing and reset value checks.")
         normalized, errors = check_reset_fill_fields(normalized, logging)
         if errors:
             raise ValidationError("Error in " + foo + ".", errors)
+
         outyaml['hart'+str(x)] = trim(normalized)
     file_name = os.path.split(foo)
     file_name_split = file_name[1].split('.')
@@ -1648,7 +1605,6 @@ def check_isa_specs(isa_spec,
         schema_yaml = add_fflags_type_setters(master_schema_yaml['hart_schema']['schema']) 
         #Extract xlen
         xlen = inp_yaml['supported_xlen']
-        rvxlen='rv'+str(xlen[0])
         validator = schemaValidator(schema_yaml, xlen=xlen, isa_string=inp_yaml['ISA'])
         validator.allow_unknown = False
         validator.purge_readonly = True
@@ -1666,6 +1622,13 @@ def check_isa_specs(isa_spec,
         else:
             error_list = validator.errors
             raise ValidationError("Error in " + foo + ".", error_list)
+
+        if logging:
+            logger.info("Initiating WARL legality checks.")
+        normalized, errors = check_warl_legality(normalized, logging)
+        if errors:
+            raise ValidationError("Error in " + foo + ".", errors)
+
         if logging:
             logger.info("Initiating post processing and reset value checks.")
         normalized, errors = check_reset_fill_fields(normalized, logging)

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -2,6 +2,7 @@ import os
 import logging
 import copy
 import re
+import math
 
 from cerberus import Validator
 
@@ -219,26 +220,11 @@ def regset():
 def pmpregset():
     global inp_yaml
     temp = {'rv32': {'accessible': False}, 'rv64': {'accessible': False}} 
-    try:   
-     if 32 in inp_yaml['supported_xlen'] and inp_yaml[temp]['rv32']['accessible'] :
-        temp['rv32']['accessible'] = True
-    except:
-        temp['rv32']['accessible'] = False
-    try: 
-     if 64 in inp_yaml['supported_xlen'] and inp_yaml[temp]['rv64']['accessible']:
-        temp['rv64']['accessible'] = True
-    except:
-        temp['rv64']['accessible'] = False
     return temp    
 
-def pmpcounterhset():
+def pmpregseth():
     global inp_yaml
     temp = {'rv32': {'accessible': False}, 'rv64': {'accessible': False}}
-    try: 
-     if 32 in inp_yaml['supported_xlen'] and inp_yaml[temp]['rv32']['accessible'] :
-        temp['rv32']['accessible'] = True
-    except:
-        temp['rv32']['accessible'] = False
     return temp
     
 def counterhset():
@@ -282,7 +268,7 @@ def add_def_setters(schema_yaml):
     reset_vsssetter=lambda doc: reset_vsstatus()
     pmpregsetter = lambda doc: pmpregset()
     counthsetter = lambda doc: counterhset()
-    pmpcounthsetter = lambda doc: pmpcounterhset()
+    pmpreghsetter = lambda doc: pmpregseth()
     uregsetter = lambda doc: uregset()
     ureghsetter = lambda doc: uregseth()
     ssetter = lambda doc: sset()
@@ -515,21 +501,21 @@ def add_def_setters(schema_yaml):
     schema_yaml['mcycleh']['default_setter'] = counthsetter
     schema_yaml['minstreth']['default_setter'] = counthsetter
     schema_yaml['pmpcfg0']['default_setter'] = pmpregsetter
-    schema_yaml['pmpcfg1']['default_setter'] = pmpcounthsetter
+    schema_yaml['pmpcfg1']['default_setter'] = pmpreghsetter
     schema_yaml['pmpcfg2']['default_setter'] = pmpregsetter
-    schema_yaml['pmpcfg3']['default_setter'] = pmpcounthsetter
+    schema_yaml['pmpcfg3']['default_setter'] = pmpreghsetter
     schema_yaml['pmpcfg4']['default_setter'] = pmpregsetter
-    schema_yaml['pmpcfg5']['default_setter'] = pmpcounthsetter
+    schema_yaml['pmpcfg5']['default_setter'] = pmpreghsetter
     schema_yaml['pmpcfg6']['default_setter'] = pmpregsetter
-    schema_yaml['pmpcfg7']['default_setter'] = pmpcounthsetter
+    schema_yaml['pmpcfg7']['default_setter'] = pmpreghsetter
     schema_yaml['pmpcfg8']['default_setter'] = pmpregsetter
-    schema_yaml['pmpcfg9']['default_setter'] = pmpcounthsetter
+    schema_yaml['pmpcfg9']['default_setter'] = pmpreghsetter
     schema_yaml['pmpcfg10']['default_setter'] = pmpregsetter
-    schema_yaml['pmpcfg11']['default_setter'] = pmpcounthsetter
+    schema_yaml['pmpcfg11']['default_setter'] = pmpreghsetter
     schema_yaml['pmpcfg12']['default_setter'] = pmpregsetter
-    schema_yaml['pmpcfg13']['default_setter'] = pmpcounthsetter
+    schema_yaml['pmpcfg13']['default_setter'] = pmpreghsetter
     schema_yaml['pmpcfg14']['default_setter'] = pmpregsetter
-    schema_yaml['pmpcfg15']['default_setter'] = pmpcounthsetter
+    schema_yaml['pmpcfg15']['default_setter'] = pmpreghsetter
     schema_yaml['pmpaddr0']['default_setter'] = pmpregsetter
     schema_yaml['pmpaddr1']['default_setter'] = pmpregsetter
     schema_yaml['pmpaddr2']['default_setter'] = pmpregsetter

--- a/riscv_config/errors.py
+++ b/riscv_config/errors.py
@@ -11,11 +11,15 @@ class ValidationError(Exception):
         '''
         error = ''
         for key in foo.keys():
-            for e in foo[key]:
-                error += space + str(key) + ":"
-                error += str(e)+"\n"
+            error += space + str(key) + ":"
+            if isinstance(foo[key][0], dict):
+                error += "\n" + self.__errPrint__(foo[key][0], space + space)
+            elif isinstance(foo[key], list):
+                for e in foo[key]:
+                    error += str(e)+"\n"
+            else:
+                error += str(foo[key][0])
             error += "\n"
-        error += "\n"
         return error.rstrip()
 
     def __str__(self):

--- a/riscv_config/errors.py
+++ b/riscv_config/errors.py
@@ -11,12 +11,11 @@ class ValidationError(Exception):
         '''
         error = ''
         for key in foo.keys():
-            error += space + str(key) + ":"
-            if isinstance(foo[key][0], dict):
-                error += "\n" + self.__errPrint__(foo[key][0], space + space)
-            else:
-                error += str(foo[key][0])
+            for e in foo[key]:
+                error += space + str(key) + ":"
+                error += str(e)+"\n"
             error += "\n"
+        error += "\n"
         return error.rstrip()
 
     def __str__(self):

--- a/riscv_config/errors.py
+++ b/riscv_config/errors.py
@@ -14,9 +14,9 @@ class ValidationError(Exception):
             error += space + str(key) + ":"
             if isinstance(foo[key][0], dict):
                 error += "\n" + self.__errPrint__(foo[key][0], space + space)
-            elif isinstance(foo[key], list):
-                for e in foo[key]:
-                    error += str(e)+"\n"
+            elif isinstance(foo[key][0], list):
+                for e in foo[key][0]:
+                    error += f'\n{space} - {e}'
             else:
                 error += str(foo[key][0])
             error += "\n"

--- a/riscv_config/schemaValidator.py
+++ b/riscv_config/schemaValidator.py
@@ -2,6 +2,7 @@ from cerberus import Validator
 import riscv_config.constants as constants
 from riscv_config.isa_validator import *
 import re
+from riscv_config.warl import warl_class
 
 
 class schemaValidator(Validator):
@@ -26,6 +27,16 @@ class schemaValidator(Validator):
         else:
             rv64 = False
         super(schemaValidator, self).__init__(*args, **kwargs)
+    
+    def _check_with_satp_modes64(self, field, value):
+
+        if 'warl' in value:
+            warl = warl_class(value['warl'], 'satp::mode',63, 60)
+            for x in [1,2,3,4,5,6,7,11,12,13]:
+                err = warl.islegal(x)
+                if not err:
+                    self._error(field, f'warl function for satp::mode accepts \
+"{x}" as a legal value - which is incorrect')
 
     def _check_with_isa_xlen(self, field, value):
         global supported_xlen

--- a/riscv_config/schemaValidator.py
+++ b/riscv_config/schemaValidator.py
@@ -1,5 +1,4 @@
 from cerberus import Validator
-from riscv_config.warl import warl_interpreter
 import riscv_config.constants as constants
 from riscv_config.isa_validator import *
 import re
@@ -342,105 +341,6 @@ class schemaValidator(Validator):
         if (min(value) < 16):
             self._error(
                 field, "Invalid platform specific values for exception cause.")
-
-    def _check_with_wr_illegal32(self, field, value):
-        '''Function to ensure the warl does not cross 2^32
-        '''
-        if 'warl' in value:
-            warlnode = warl_interpreter(value['warl'])
-            x = 0x8000000000000000
-            if (len(value['warl']['legal']) > 1):
-                while (x > 0x10000000):
-                    if warlnode.islegal(x):
-                        self._error(
-                            field, "Must have a warl which is only 32-bits. Value"  + \
-                                        str(hex(x)) + " was considered legal")
-                        break
-                    x = x>> 1
-            else:
-                for l in value['warl']['legal']:
-                    if 'bitmask' in l:
-                        bmask = re.findall(r'\s*\[.*\]\s*bitmask\s*\[(.*?)\]',l)[0]
-                        maxval_str = bmask.split(',')[0]
-                        if '0x' in maxval_str:
-                            maxval = int(maxval_str,16)
-                        else:
-                            maxval = int(maxval_str,10)
-                        if maxval > 0xFFFFFFFF:
-                            self._error(
-                                field, "Must have a warl which is only 32-bits. Value"  + \
-                                        str(hex(maxval)) + " was considered legal")
-                    else:
-                        while (x > 0x10000000):
-                            if warlnode.islegal(x):
-                                self._error(
-                                    field, "Must have a warl which is only 32-bits. Value"  + \
-                                                str(hex(x)) + " was considered legal")
-                                break
-                            x = x>> 1
-
-    def _check_with_wr_illegal(self, field, value):
-        pr = 0
-        pri = 0
-        if 'warl' not in value.keys():
-            return
-        for i in range(len(value['warl']['legal'])):
-            if ' -> ' in value['warl']['legal'][i]:
-                pr = 1
-                break
-        if value['warl']['wr_illegal'] != None:
-            for i in range(len(value['warl']['wr_illegal'])):
-                split = re.findall(r'^\s*\[(\d)]\s*',
-                                   value['warl']['wr_illegal'][i])
-                if split != []:
-                    pri = 1
-                    break
-        if value['warl']['dependency_fields'] != []:
-            l = (len(value['warl']['legal']))
-            f = 0
-            for i in range(l):
-                if "bitmask" in value['warl']['legal'][i]:
-                    f = 1
-                    splits = re.findall(
-                        r'(\[\d\])\s*->\s*.*\s*\[.*\]\s*{}\s*\[.*?[,|:].*?]'.
-                        format("bitmask"), value['warl']['legal'][i])
-                    if value['warl']['wr_illegal'] != None:
-                        for j in range(len(value['warl']['wr_illegal'])):
-                            if splits[0] in value['warl']['wr_illegal'][j]:
-                                self._error(
-                                    field,
-                                    "illegal value does not exist for the given mode{}(bitmask)"
-                                    .format(splits[0]))
-            if f == 0:
-                pass
-
-        elif value['warl']['dependency_fields'] == [] and pr == 1:
-            self._error(field, "since dependency_fields is empty no '->' in legal fields")
-        elif value['warl']['dependency_fields'] == [] and len(value['warl']['legal']) != 1:
-            self._error(field, "There should be only one legal string")
-        elif value['warl']['dependency_fields'] == [] and pri == 1:
-            self._error(field, "since dependency_fields is empty illegal fields must be defined for each")
-        else:
-            for l in value['warl']['legal']:
-                if 'bitmask' in l:
-                    bmask = re.findall(r'\s*\[.*\]\s*bitmask\s*\[(.*?)\]',l)[0]
-                    if ',' not in bmask:
-                        self._error(field, 'Legal string "'+l+'" has wrong bitmask syntax')
-                    if len(bmask.split(','))!=2:
-                        self._error(field, 'Legal string "'+l+'" has wrong bitmkask syntax')
-                    for v in bmask.split(','):
-                        if '0x' not in v:
-                            try:
-                                isinstance(int(v,10),int)
-                            except:
-                                self._error(field, 'Value ' +str(v) + ' in Legal string "'+l+'" is not a valid number')
-
-
-#        elif value['warl']['dependency_fields'] == [] and len(
-#                value['warl']['legal']
-#        ) == 1 and value['warl']['wr_illegal'] != None and "bitmask" in value[
-#                'warl']['legal'][0]:
-#            self._error(field, "illegal value cannot exist for bitmask type")
 
     def _check_with_key_check(self, field, value):
         if value['base']['type']['warl']['dependency_fields'] != []:

--- a/riscv_config/schemas/schema_debug.yaml
+++ b/riscv_config/schemas/schema_debug.yaml
@@ -129,7 +129,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                     - schema: { wlrl: *ref_wlrl }
                     - schema: { warl: *ref_warl }
@@ -153,7 +152,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                     - schema: { wlrl: *ref_wlrl }
                     - schema: { warl: *ref_warl }
@@ -179,7 +177,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
                   - schema: {ro_variable: {type: boolean}}
@@ -198,7 +195,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -225,7 +221,6 @@ hart_schema:
                 type:
                   type: dict
                   check_with: 
-                    - wr_illegal
                     - s_debug_check
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
@@ -247,7 +242,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
                   - schema: {ro_variable: {type: boolean}}
@@ -267,7 +261,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -292,7 +285,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
@@ -317,7 +309,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -343,7 +334,6 @@ hart_schema:
                 type:
                   type: dict
                   check_with: 
-                    - wr_illegal
                     - u_debug_check
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
@@ -365,7 +355,6 @@ hart_schema:
                 type:
                   type: dict
                   check_with: 
-                    - wr_illegal
                     - s_debug_check
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -386,7 +375,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -413,7 +401,6 @@ hart_schema:
                 type:
                   type: dict
                   check_with: 
-                    - wr_illegal
                     - s_debug_check
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -435,7 +422,6 @@ hart_schema:
                 type:
                   type: dict
                   check_with: 
-                    - wr_illegal
                     - s_debug_check
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -456,7 +442,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: {ro_constant: {type: integer, max: 15 , min : 0}}
                   default: {ro_constant: 4}
               default: {implemented: false}
@@ -480,7 +465,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                     - schema: { wlrl: *ref_wlrl }
                     - schema: { warl: *ref_warl }
@@ -504,7 +488,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                     - schema: { wlrl: *ref_wlrl }
                     - schema: { warl: *ref_warl }
@@ -530,7 +513,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
                   - schema: {ro_variable: {type: boolean}}
@@ -549,7 +531,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -576,7 +557,6 @@ hart_schema:
                 type:
                   type: dict
                   check_with: 
-                    - wr_illegal
                     - s_debug_check
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
@@ -598,7 +578,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: { ro_variable: {type: boolean}}
                   default:
                     ro_variable: True
@@ -616,7 +595,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -641,7 +619,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
@@ -666,7 +643,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -692,7 +668,6 @@ hart_schema:
                 type:
                   type: dict
                   check_with: 
-                    - wr_illegal
                     - u_debug_check
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
@@ -714,7 +689,6 @@ hart_schema:
                 type:
                   type: dict
                   check_with: 
-                    - wr_illegal
                     - s_debug_check
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -735,7 +709,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -762,7 +735,6 @@ hart_schema:
                 type:
                   type: dict
                   check_with: 
-                    - wr_illegal
                     - s_debug_check
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -784,7 +756,6 @@ hart_schema:
                 type:
                   type: dict
                   check_with: 
-                    - wr_illegal
                     - s_debug_check
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -805,7 +776,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: {ro_constant: {type: integer, max: 15 , min : 0}}
                   default: {ro_constant: 4}
               default: {implemented: false}
@@ -837,7 +807,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: {ro_variable: {type: boolean}}
@@ -864,7 +833,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFFFFFFFFFF}}
               - schema: {ro_variable: {type: boolean}}
@@ -904,7 +872,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: {ro_variable: {type: boolean}}
@@ -931,7 +898,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFFFFFFFFFF}}
               - schema: {ro_variable: {type: boolean}}
@@ -970,7 +936,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -995,7 +960,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:

--- a/riscv_config/schemas/schema_debug.yaml
+++ b/riscv_config/schemas/schema_debug.yaml
@@ -25,7 +25,7 @@ hart_schema:
       required: true
     ###
     #Debug_Spec_Version
-    #-----------------
+    #------------------
     #
     # **Description**: Version number of Debug specification as string. Please enclose the version in "" to avoid type mismatches.
     #
@@ -44,6 +44,8 @@ hart_schema:
     
     ###
     #debug_mode
+    #----------
+    #
     #  **Description**: Boolean value indicating if the debug instructions are accessible.
     #
     #  **Examples**:
@@ -59,11 +61,13 @@ hart_schema:
 
     ###
     #parking_loop
+    #------------
+    #
     #  **Description**: Integer value indicating the address of the debug parking loop
     #
     #  **Examples**:
     #
-    #  .. code-block: yaml
+    #  .. code-block:: yaml
     #
     #     parking_loop: 0x800
 

--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -3725,7 +3725,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp0cfg: &pmp0
               type: dict
@@ -3799,7 +3799,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv64_check}
+            accessible: {type: boolean, default: false, check_with: rv64_check}
             fields: {type: list, default: []}
             pmp0cfg: 
               <<: *pmp0
@@ -3889,7 +3889,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp4cfg: 
               <<: *pmp0
@@ -3917,7 +3917,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp8cfg: 
               <<: *pmp0
@@ -3931,7 +3931,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv64_check}
+            accessible: {type: boolean, default: false, check_with: rv64_check}
             fields: {type: list, default: []}
             pmp8cfg: 
               <<: *pmp0
@@ -3960,7 +3960,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp12cfg: 
               <<: *pmp0
@@ -3987,7 +3987,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp16cfg: 
               <<: *pmp0
@@ -4001,7 +4001,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv64_check}
+            accessible: {type: boolean, default: false, check_with: rv64_check}
             fields: {type: list, default: []}
             pmp16cfg: 
               <<: *pmp0
@@ -4030,7 +4030,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp20cfg: 
               <<: *pmp0
@@ -4057,7 +4057,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp24cfg: 
               <<: *pmp0
@@ -4071,7 +4071,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv64_check}
+            accessible: {type: boolean, default: false, check_with: rv64_check}
             fields: {type: list, default: []}
             pmp24cfg: 
               <<: *pmp0
@@ -4100,7 +4100,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp28cfg: 
               <<: *pmp0
@@ -4127,7 +4127,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp32cfg: 
               <<: *pmp0
@@ -4141,7 +4141,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv64_check}
+            accessible: {type: boolean, default: false, check_with: rv64_check}
             fields: {type: list, default: []}
             pmp32cfg: 
               <<: *pmp0
@@ -4170,7 +4170,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp36cfg: 
               <<: *pmp0
@@ -4197,7 +4197,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp40cfg: 
               <<: *pmp0
@@ -4211,7 +4211,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv64_check}
+            accessible: {type: boolean, default: false, check_with: rv64_check}
             fields: {type: list, default: []}
             pmp40cfg: 
               <<: *pmp0
@@ -4240,7 +4240,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp44cfg: 
               <<: *pmp0
@@ -4267,7 +4267,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp48cfg: 
               <<: *pmp0
@@ -4281,7 +4281,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv64_check}
+            accessible: {type: boolean, default: false, check_with: rv64_check}
             fields: {type: list, default: []}
             pmp48cfg: 
               <<: *pmp0
@@ -4310,7 +4310,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp52cfg: 
               <<: *pmp0
@@ -4337,7 +4337,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp56cfg: 
               <<: *pmp0
@@ -4351,7 +4351,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv64_check}
+            accessible: {type: boolean, default: false, check_with: rv64_check}
             fields: {type: list, default: []}
             pmp56cfg: 
               <<: *pmp0
@@ -4380,7 +4380,7 @@ hart_schema:
           type: dict
           default: {accessible: False}
           schema:
-            accessible: {type: boolean, default: true, check_with: rv32_check}
+            accessible: {type: boolean, default: false, check_with: rv32_check}
             fields: {type: list, default: []}
             pmp60cfg: 
               <<: *pmp0

--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -290,7 +290,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: { warl: *ref_warl }
@@ -312,7 +311,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max: 0xFFFFFFFFFFFFFFFF}}
               - schema: { warl: *ref_warl }
@@ -339,7 +337,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF }}
               - schema: { warl: *ref_warl }
@@ -378,7 +375,6 @@ hart_schema:
                 implemented: { type: boolean, default: false }
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                     - schema: {ro_constant: {type: integer, max: 0x3, min: 0x1}}
                     - schema: {ro_variable: {type: boolean}}
@@ -405,7 +401,6 @@ hart_schema:
                 implemented: {type: boolean, default: false}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  0x3ffffff}}
                   - schema: {ro_variable: {type: boolean}}
@@ -441,7 +436,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  3, min: 1}}
                   - schema: {ro_variable: {type: boolean}}
@@ -468,7 +462,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  0x3ffffff}}
                   - schema: {ro_variable: {type: boolean}}
@@ -514,7 +507,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -535,7 +527,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -558,7 +549,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: { wlrl: *ref_wlrl }
                   default: { wlrl: [0:1] }
               default: {implemented: true}
@@ -575,7 +565,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -599,7 +588,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -623,7 +611,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: { wlrl: *ref_wlrl }
                   default: { wlrl: [0:1]}
               default: {implemented: true}
@@ -640,7 +627,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -661,7 +647,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
@@ -682,7 +667,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -709,7 +693,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -730,7 +713,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -758,7 +740,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -785,7 +766,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -813,7 +793,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -840,7 +819,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -861,7 +839,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -889,7 +866,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal 
                   oneof:
                   - schema: {ro_variable: {type: boolean}}
                   - schema: { warl: *ref_warl }
@@ -918,7 +894,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -939,7 +914,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -962,7 +936,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: { wlrl: *ref_wlrl }
                   default: { wlrl: [0:1] }
               default: {implemented: true}
@@ -979,7 +952,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -1003,7 +975,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -1027,7 +998,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: { wlrl: *ref_wlrl }
                   default: { wlrl: [0:1]}
               default: {implemented: true}
@@ -1044,7 +1014,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -1065,7 +1034,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
@@ -1086,7 +1054,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -1114,7 +1081,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
                   - schema: {ro_variable: {type: boolean}}
@@ -1136,7 +1102,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -1164,7 +1129,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -1191,7 +1155,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -1219,7 +1182,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -1246,7 +1208,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -1267,7 +1228,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -1294,7 +1254,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 2, min: 1}}
                   - schema: { warl: *ref_warl }
@@ -1313,7 +1272,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  2, min: 1}}
                   - schema: { warl: *ref_warl }
@@ -1334,7 +1292,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -1355,7 +1312,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -1377,7 +1333,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal 
                   oneof:
                   - schema: {ro_variable: {type: boolean}}
                   - schema: { warl: *ref_warl }
@@ -1420,7 +1375,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -1439,7 +1393,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -1458,7 +1411,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -1476,7 +1428,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -1729,7 +1680,6 @@ hart_schema:
                 implemented: {type: boolean, default: true, allowed: [true]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  1073741823}}
                   - schema: {ro_variable: {type: boolean}}
@@ -1755,7 +1705,6 @@ hart_schema:
                 implemented: {type: boolean, default: true, allowed: [true]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  1}}
                   - schema: {ro_variable: {type: boolean}}
@@ -1791,7 +1740,6 @@ hart_schema:
                 implemented: {type: boolean, default: true, allowed: [true]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  4611686018427387903}}
                   - schema: {ro_variable: {type: boolean}}
@@ -1817,7 +1765,6 @@ hart_schema:
                 implemented: {type: boolean, default: true, allowed: [true]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  1}}
                   - schema: {ro_variable: {type: boolean}}
@@ -1859,7 +1806,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -1885,7 +1831,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -1926,7 +1871,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -1952,7 +1896,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -1999,7 +1942,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2021,7 +1963,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2043,7 +1984,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2086,7 +2026,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2108,7 +2047,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2130,7 +2068,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2173,7 +2110,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2195,7 +2131,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2217,7 +2152,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2260,7 +2194,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2294,7 +2227,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2316,7 +2248,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2338,7 +2269,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2381,7 +2311,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2403,7 +2332,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2425,7 +2353,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2468,7 +2395,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2490,7 +2416,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2512,7 +2437,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2555,7 +2479,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2600,7 +2523,6 @@ hart_schema:
                 lsb: {type: integer, default: 2, allowed: [2]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2623,7 +2545,6 @@ hart_schema:
                 lsb: {type: integer, default: 6, allowed: [6]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2646,7 +2567,6 @@ hart_schema:
                 lsb: {type: integer, default: 10, allowed: [10]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2671,7 +2591,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2702,7 +2621,6 @@ hart_schema:
                 lsb: {type: integer, default: 2, allowed: [2]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2725,7 +2643,6 @@ hart_schema:
                 lsb: {type: integer, default: 6, allowed: [6]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2748,7 +2665,6 @@ hart_schema:
                 lsb: {type: integer, default: 10, allowed: [10]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2773,7 +2689,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2820,7 +2735,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2842,7 +2756,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2862,7 +2775,6 @@ hart_schema:
                 implemented: {type: boolean, default: True}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2887,7 +2799,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: { wlrl: *ref_wlrl }
                   default:
                     wlrl: 
@@ -2908,7 +2819,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2930,7 +2840,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2950,7 +2859,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -2975,7 +2883,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: { wlrl: *ref_wlrl }
                   default: 
                     wlrl: 
@@ -2995,7 +2902,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3017,7 +2923,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3037,7 +2942,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3062,7 +2966,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: { wlrl: *ref_wlrl }
                   default: 
                     wlrl: [0:1]
@@ -3079,7 +2982,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3113,7 +3015,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3135,7 +3036,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3155,7 +3055,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3180,7 +3079,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: { wlrl: *ref_wlrl }
                   default:
                     wlrl: 
@@ -3201,7 +3099,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3223,7 +3120,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3243,7 +3139,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3268,7 +3163,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: { wlrl: *ref_wlrl }
                   default: 
                     wlrl: 
@@ -3288,7 +3182,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3310,7 +3203,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3330,7 +3222,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3355,7 +3246,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: { wlrl: *ref_wlrl }
                   default: 
                     wlrl: [0:1]
@@ -3372,7 +3262,6 @@ hart_schema:
                 implemented: {type: boolean}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -3410,7 +3299,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: {ro_variable: {type: boolean}}
@@ -3437,7 +3325,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFFFFFFFFFF}}
               - schema: {ro_variable: {type: boolean}}
@@ -3477,7 +3364,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -3502,7 +3388,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -3540,7 +3425,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -3565,7 +3449,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -3747,7 +3630,6 @@ hart_schema:
                 implemented: {type: boolean, default: true, allowed: [true]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -3816,7 +3698,6 @@ hart_schema:
                 implemented: {type: boolean, default: true, allowed: [true]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -3857,7 +3738,6 @@ hart_schema:
                 implemented: {type: boolean, default: false}
                 type: 
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                     - schema: {ro_constant: {type: integer, max:  0xFF}}
                     - schema: { warl: *ref_warl }
@@ -3875,7 +3755,6 @@ hart_schema:
                 implemented: {type: boolean, default: false}
                 type: 
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                     - schema: {ro_constant: {type: integer, max:  0xFF}}
                     - schema: { warl: *ref_warl }
@@ -3893,7 +3772,6 @@ hart_schema:
                 implemented: {type: boolean, default: false}
                 type: 
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                     - schema: {ro_constant: {type: integer, max:  0xFF}}
                     - schema: { warl: *ref_warl }
@@ -3911,7 +3789,6 @@ hart_schema:
                 implemented: {type: boolean, default: false}
                 type: 
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                     - schema: {ro_constant: {type: integer, max:  0xFF}}
                     - schema: { warl: *ref_warl }
@@ -3943,7 +3820,6 @@ hart_schema:
                 implemented: {type: boolean, default: false}
                 type: 
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  0xFF}}
                   - schema: { warl: *ref_warl }
@@ -3961,7 +3837,6 @@ hart_schema:
                 implemented: {type: boolean, default: false}
                 type: 
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  0xFF}}
                   - schema: { warl: *ref_warl }
@@ -3979,7 +3854,6 @@ hart_schema:
                 implemented: {type: boolean, default: false}
                 type: 
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  0xFF}}
                   - schema: { warl: *ref_warl }
@@ -3997,7 +3871,6 @@ hart_schema:
                 implemented: {type: boolean, default: false}
                 type: 
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  0xFF}}
                   - schema: { warl: *ref_warl }
@@ -5057,7 +4930,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: { warl: *ref_warl }
@@ -5079,9 +4951,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: 
-                - wr_illegal
-                - wr_illegal32
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: { warl: *ref_warl }
@@ -5111,7 +4980,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: { warl: *ref_warl }
@@ -5128,9 +4996,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: 
-                - wr_illegal
-                - wr_illegal32
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: { warl: *ref_warl }
@@ -5157,7 +5022,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: { warl: *ref_warl }
@@ -5183,7 +5047,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max: 0xFFFFFFFFFFFFFFFF}}
               - schema: { warl: *ref_warl }
@@ -5219,7 +5082,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF }}
               - schema: { warl: *ref_warl }
@@ -5260,7 +5122,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: { warl: *ref_warl }
@@ -5286,7 +5147,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max: 0xFFFFFFFFFFFFFFFF}}
               - schema: { warl: *ref_warl }
@@ -5322,7 +5182,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF }}
               - schema: { warl: *ref_warl }
@@ -6066,7 +5925,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: {ro_variable: {type: boolean}}
@@ -6085,7 +5943,6 @@ hart_schema:
             lsb: {type: integer, default: 2, allowed: [2]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  4611686018427387903}}
               - schema: {ro_variable: {type: boolean}}
@@ -6117,7 +5974,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  4611686018427387903}}
               - schema: {ro_variable: {type: boolean}}
@@ -6136,7 +5992,6 @@ hart_schema:
             lsb: {type: integer, default: 2, allowed: [2]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  4611686018427387903}}
               - schema: {ro_variable: {type: boolean}}
@@ -6245,7 +6100,6 @@ hart_schema:
                 implemented: {type: boolean, default: false}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                     - schema: {ro_constant: {type: integer, max: 0x7}}
                     - schema: { warl: *ref_warl }
@@ -6268,7 +6122,6 @@ hart_schema:
                 implemented: {type: boolean, default: false}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                     - schema: {ro_constant: {type: integer, max: 0x1F}}
                     - schema: { warl: *ref_warl }
@@ -6301,7 +6154,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                     - schema: {ro_constant: {type: integer, max: 0x7}}
                     - schema: { warl: *ref_warl }
@@ -6324,7 +6176,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                     - schema: {ro_constant: {type: integer, max: 0x1F}}
                     - schema: { warl: *ref_warl }
@@ -8672,7 +8523,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: {ro_variable: {type: boolean}}
@@ -8700,7 +8550,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFFFFFFFFFF}}
               - schema: {ro_variable: {type: boolean}}
@@ -8740,7 +8589,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -8766,7 +8614,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -8805,7 +8652,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -8831,7 +8677,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -8984,7 +8829,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  1073741823}}
                   - schema: {ro_variable: {type: boolean}}
@@ -9011,7 +8855,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  1}}
                   - schema: {ro_variable: {type: boolean}}
@@ -9048,7 +8891,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  4611686018427387903}}
                   - schema: {ro_variable: {type: boolean}}
@@ -9075,7 +8917,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  1}}
                   - schema: {ro_variable: {type: boolean}}
@@ -9162,7 +9003,6 @@ hart_schema:
                 implemented: {type: boolean, default: true, allowed: [true]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -9236,7 +9076,6 @@ hart_schema:
                 implemented: {type: boolean, default: true, allowed: [true]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -9722,7 +9561,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: {ro_variable: {type: boolean}}
@@ -9750,7 +9588,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFFFFFFFFFF}}
               - schema: {ro_variable: {type: boolean}}
@@ -9791,7 +9628,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -9817,7 +9653,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -9856,7 +9691,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -9882,7 +9716,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -10036,7 +9869,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  1073741823}}
                   - schema: {ro_variable: {type: boolean}}
@@ -10063,7 +9895,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  1}}
                   - schema: {ro_variable: {type: boolean}}
@@ -10100,7 +9931,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  4611686018427387903}}
                   - schema: {ro_variable: {type: boolean}}
@@ -10127,7 +9957,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  1}}
                   - schema: {ro_variable: {type: boolean}}
@@ -10168,7 +9997,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -10193,9 +10021,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: 
-                - wr_illegal
-                - wr_illegal32
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -10237,7 +10062,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -10255,7 +10079,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -10276,7 +10099,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: { wlrl: *ref_wlrl }
                   default: { wlrl: [0:1] }
               default: {implemented: false}
@@ -10294,7 +10116,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -10315,7 +10136,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -10336,7 +10156,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: {ro_constant: {type: integer, max:  64, min : 0}}
                   default: {ro_constant: 0}
               default: {implemented: true}
@@ -10353,7 +10172,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -10373,7 +10191,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
@@ -10393,7 +10210,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -10426,7 +10242,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -10444,7 +10259,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -10465,7 +10279,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema: { wlrl: *ref_wlrl }
                   default: { wlrl: [0:1] }
               default: {implemented: false}
@@ -10483,7 +10296,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -10504,7 +10316,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -10525,7 +10336,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   schema:  {ro_constant: {type: integer, max:  64, min : 0}}
                   default: {ro_constant: 0}
               default: {implemented: true}
@@ -10542,7 +10352,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -10562,7 +10371,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
@@ -10582,7 +10390,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: {ro_constant: {type: integer, max: 1 , min : 0}}
@@ -10608,7 +10415,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 2, min: 1}}
                   - schema: { warl: *ref_warl }
@@ -10643,7 +10449,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -10669,7 +10474,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -10708,7 +10512,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -10734,7 +10537,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -10779,7 +10581,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -10805,7 +10606,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -10825,7 +10625,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -10872,7 +10671,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -10897,7 +10695,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -10917,7 +10714,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -10976,7 +10772,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -11001,7 +10796,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -11026,7 +10820,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -11060,7 +10853,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -11085,7 +10877,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -11110,7 +10901,6 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { wlrl: *ref_wlrl }
                   - schema: { warl: *ref_warl }
@@ -11149,7 +10939,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
                     - schema: {ro_constant: {type: integer, max: 0x3, min: 0x1}}
                     - schema: {ro_variable: {type: boolean}}  
@@ -11170,7 +10959,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
                     - schema: {ro_constant: {type: integer, max: 0x3, min: 0x1}}
                     - schema: {ro_variable: {type: boolean}}
@@ -11203,7 +10991,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -11228,7 +11015,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -11308,7 +11094,6 @@ hart_schema:
                 implemented: {type: boolean, default: true, allowed: [true]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -11379,7 +11164,6 @@ hart_schema:
                 implemented: {type: boolean, default: true, allowed: [true]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max: 3 , min : 0}}
                   - schema: { warl: *ref_warl }
@@ -11420,7 +11204,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -11445,7 +11228,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -11481,7 +11263,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -11506,7 +11287,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -11542,7 +11322,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -11567,7 +11346,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -11603,7 +11381,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -11628,7 +11405,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -11793,7 +11569,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -11818,7 +11593,6 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -11942,7 +11716,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -11961,7 +11734,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -11982,7 +11754,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12004,7 +11775,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12025,7 +11795,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12047,7 +11816,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 13, allowed: [13]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12068,7 +11836,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 15, allowed: [15]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12089,7 +11856,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 18, allowed: [18]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12110,7 +11876,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 19, allowed: [19]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12132,7 +11897,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 31, allowed: [31]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12159,7 +11923,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12178,7 +11941,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12199,7 +11961,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12221,7 +11982,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12242,7 +12002,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12264,7 +12023,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 13, allowed: [13]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12285,7 +12043,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 15, allowed: [15]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12306,7 +12063,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 18, allowed: [18]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12327,7 +12083,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 19, allowed: [19]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: { warl: *ref_warl }
                   - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
@@ -12346,7 +12101,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 32, allowed: [32]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  2, min: 1}}
                   - schema: { warl: *ref_warl }
@@ -12368,7 +12122,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 lsb: {type: integer, default: 63, allowed: [63]}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_variable: {type: boolean}}
                   - schema: { warl: *ref_warl }
@@ -12587,7 +12340,6 @@ CSR and the value returned in VS-mode or VU-mode.}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFF}}
               - schema: {ro_variable: {type: boolean}}
@@ -12615,7 +12367,6 @@ CSR and the value returned in VS-mode or VU-mode.}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               oneof:
               - schema: {ro_constant: {type: integer, max:  0xFFFFFFFFFFFFFFFF}}
               - schema: {ro_variable: {type: boolean}}
@@ -12656,7 +12407,6 @@ CSR and the value returned in VS-mode or VU-mode.}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -12681,7 +12431,6 @@ CSR and the value returned in VS-mode or VU-mode.}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -12719,7 +12468,6 @@ CSR and the value returned in VS-mode or VU-mode.}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -12745,7 +12493,6 @@ CSR and the value returned in VS-mode or VU-mode.}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              check_with: wr_illegal
               schema: { warl: *ref_warl }
               default:
                 warl:
@@ -12895,7 +12642,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  1073741823}}
                   - schema: {ro_variable: {type: boolean}}
@@ -12921,7 +12667,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  1}}
                   - schema: {ro_variable: {type: boolean}}
@@ -12957,7 +12702,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  4611686018427387903}}
                   - schema: {ro_variable: {type: boolean}}
@@ -12983,7 +12727,6 @@ CSR and the value returned in VS-mode or VU-mode.}
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
-                  check_with: wr_illegal
                   oneof:
                   - schema: {ro_constant: {type: integer, max:  1}}
                   - schema: {ro_variable: {type: boolean}}

--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -9163,13 +9163,13 @@ hart_schema:
                 type:
                   type: dict
                   oneof:
-                  - schema: {ro_constant: {type: integer, max:  1}}
+                  - schema: {ro_constant: {type: integer, allowed: [0,1]}}
                   - schema: { warl: *ref_warl }
                   default: 
                     warl:
                         dependency_fields: []
                         legal:
-                          - asid[0] in [0x0,0x1]
+                          - mode[0] in [0x0,0x1]
                         wr_illegal:
                           - Unchanged
               default: {implemented: False}
@@ -9247,14 +9247,15 @@ hart_schema:
                 implemented: {type: boolean, default: true}
                 type:
                   type: dict
+                  check_with: satp_modes64
                   oneof:
-                  - schema: {ro_constant: {type: integer, max:  15}}
+                  - schema: {ro_constant: {type: integer, allowed: [0,8,9,10,14,15]}}
                   - schema: { warl: *ref_warl }
                   default: 
                     warl:
                         dependency_fields: []
                         legal:
-                          - asid[3:0] in [0, 8, 9]
+                          - mode[3:0] in [0, 8, 9, 10]
                         wr_illegal:
                           - Unchanged
               default: {implemented: False}

--- a/riscv_config/warl.py
+++ b/riscv_config/warl.py
@@ -494,11 +494,11 @@ in that string')
 values in warl string "{legalstr}" for csr {csrname}')
            
             if bitcount < 0:
-                err.append(f' warl string {legalstr} defines values for bits \
-outside the size of the register {reg_bitlen}')
+                err.append(f' warl string "{legalstr}" defines values for bits \
+outside the size of the register "{reg_bitlen}"')
             elif bitcount != 0:
-                err.append(f' warl string {legalstr} for csr \
-{csrname} either does not define values for all bits or has overlapping ranges \
+                err.append(f' warl string "{legalstr}" for csr \
+"{csrname}" either does not define values for all bits or has overlapping ranges \
 defining the same bits multiple times')
 
         return err

--- a/riscv_config/warl.py
+++ b/riscv_config/warl.py
@@ -6,435 +6,500 @@ import textwrap
 
 logger = logging.getLogger(__name__)
 
-class warl_interpreter():
-    global val
-    global bitsum
-    global dep_val
+class warl_class():
+    """This is a class for handling various operations and checks for the WARL
+    type of registers and/or subfields as defined by the riscv-config spec<TODO: 
+    link here>. While riscv-config remains to be the major user of this package,
+    this class can be used as an importable python package as well in several
+    other scenarios to perform checks on a particular WARL string.
 
-    def __init__(self, warl):
-        ''' the warl_description in the yaml is given as input to the constructor '''
-        self.warl = warl
-        self.dependencies = warl['dependency_fields']
-        self.exp  = re.compile('(?P<csr>.*?)\[(?P<csr_ind>.*?)\]\s*(?P<csr_op>.*?)\s*\[(?P<csr_vals>.*?)\]')
-        self.rexp = re.compile('(?P<csr>.*?)\[(?P<csr_ind>.*?)\]\s*(in|bitmask)\s*\s*\[(?P<csr_vals>.*?)\]')
-        self.rexp_dependencies = re.compile('(?P<dep_csr>.*?)\[(?P<dep_ind>.*?)\]\s*(in|bitmask)\s*\[(?P<dep_vals>.*?)\]\s*->\s*(?P<csr>.*?)\[(?P<csr_ind>.*?)\]\s*(in|bitmask)\s*\s*\[(?P<csr_vals>.*?)\]')
+    The basic WARL node should be dict adhering to the following syntax:
 
-    def prevsum(self, i, k):
-        sump = 0
-        for j in range(i + 1):
-            sump = sump + k[j]
-        return sump
+    .. code-block:: yaml
+        
+        warl:
+           dependency_fields: [list]
+           legal: [list of warl-string]
+           wr_illegal: [list of warl-string]
 
-    def islegal(self, value, dependency_vals=[]):
-        is_legal = False
-        logger.debug('Checking for isLegal for WARL: \n' +
-                textwrap.indent(utils.pretty_print_yaml(self.warl),'           ')
-                        + '\n With following args:'
-                        + 'val : ' + str(value) + ' dep_vals :'+
-                        str(dependency_vals))
-        if not self.dependencies: # no dependencies in the warl
-            for legal_str in self.warl['legal']: # iterate over every legal str
-                search = self.exp.findall(legal_str)
-                if search is None:
-                    logger.error('Warl legal string is wrong:' + legal_str)
-                    raise SystemExit
-                part_legal = False
-                for part in search:
-                    (csr, csr_ind, csr_op, csr_vals) = part
-                    msb = int(csr_ind.split(':')[0])
-                    lsb = int(csr_ind.split(':')[-1])
-                    bitmask = True if 'bitmask' in csr_op else False
+    :param node: This input is the dict adhering to the above syntax.
+    :type node: dict
+    :param csrname: this is string indicating the name of the csr or
+        csr::subfield which is defined as a WARL type. This primarily used to
+        generate a series of legible error and debug messages. If the input warl
+        node is for a subfield, then use ``::`` as the delimiter between the csr
+        name and the subfield name.
+    :type csrname: str
+    :param f_msb: the max msb location of the csr or subfield.
+    :type f_msb: int
+    :param f_lsb: the min lsb location of the csr or subfield.
+    :type f_lsb: int
+    :param spec: This is the entire isa-spec of a single hart. This dict is
+        primarily used by this class to perform specific checks on reset-vals
+        and on dependency_vals string validity.
+    :type spec: dict
 
-                    if not bitmask: # if its not a bitmask
-                        if ":" in csr_vals: # range is specified
-                            [base, bound] = csr_vals.split(':')
-                            base = int(base, 0)
-                            bound = int(bound, 0)
-                            if value >= base and value <= bound: # check legal range
-                                part_legal = True
-                        else:
-                            l_vals = csr_vals.split(',')
-                            legal_vals = []
-                            for i in l_vals : 
-                                legal_vals.append(int(i,0))
-                            if value in legal_vals:
-                                part_legal = True
-                    else: # in case of bitmask there are no illegal values
-                        part_legal = True
-                    if not part_legal:
-                        break
-                if part_legal:
-                    is_legal = True
-        else: # there are dependencies
-            if len(self.dependencies) != len(dependency_vals):
-                logger.error('length of dependency_vals not the same as dependencies')
-                raise SystemExit
-            leaf_dependencies = []
-            for d in self.dependencies:
-                leaf_dependencies.append(d.split('::')[-1])
-            for legal_str in self.warl['legal']: # iterate over legal str
-                dep_str = legal_str.split('->')[0]
-                csr_str = legal_str.split('->')[1]
-                csr_search = self.exp.findall(csr_str)
-                dep_search = self.exp.search(dep_str)
-                if csr_search is None or dep_search  is None:
-                    logger.error('Warl legal string is wrong :\n\t' + legal_str)
-                    raise SystemExit(1)
-                dep_csr = dep_search.group('csr')
-                dep_ind = dep_search.group('csr_ind')
-                if ':' in dep_ind:
-                    msb = int(dep_ind.split(':')[0],0)
-                    lsb = int(dep_ind.split(':')[1],0)
-                else:
-                    lsb = int(dep_ind,0)
-                    msb = lsb
-                if (msb < lsb):
-                    logger.error('msb < lsb for in dependency field of warl:\n\n' + 
-                            utils.pretty_print_yaml(self.warl))
-                    raise SystemExit(1)
-                dep_vals = dep_search.group('csr_vals')
-                dep_bitmask = True if 'bitmask' in legal_str.split('->')[0] else False
+    """
+    
+    def __init__(self, node, csrname, f_msb, f_lsb, spec=None):
+        """Constructor Method
+        """
 
-                if dep_csr not in leaf_dependencies:
-                    logger.error(\
-            'Found a dependency in the legal_str which is not present in the dependency_fields of the warl:\n\n' + \
-                    utils.pretty_print_yaml(self.warl))
-                    raise SystemExit
-                dep_satified = False
-                recvd_val = dependency_vals[leaf_dependencies.index(dep_csr)]
-                recvd_val = (recvd_val >> lsb) & ((1<<(msb-lsb))-1)
+        self.node = node
+        self.f_msb = f_msb
+        self.f_lsb = f_lsb
+        self.spec = spec
+        self.regex_legal = re.compile('\[(.*?)\]\s*(bitmask|in|not in)\s*\[(.*?)\]')
+        self.regex_dep_legal = re.compile('(?P<csrname>.*?)\s*\[(?P<indices>.*?)\]\s*(?P<op>in|not in.*?)\s*\[(?P<values>.*?)\]\s*')
+        self.dependencies = node['dependency_fields']
+        self.csrname = csrname
+        if spec is not None:
+            self.isa = 'rv32' if '32' in spec['ISA'] else 'rv64'
 
-                # check if the dependency value is satisfied.
-                if ":" in dep_vals: # range is specified
-                    [base, bound] = dep_vals.split(':')
-                    base = int(base, 0)
-                    bound = int(bound, 0)
-                    if recvd_val >= base and recvd_val <= bound: # check legal range
-                        dep_satified = True
-                else:
-                    l_vals = dep_vals.split(',')
-                    legal_vals = []
-                    for i in l_vals : 
-                        legal_vals.append(int(i,0))
-                    if recvd_val in legal_vals:
-                        dep_satified = True
-                
-                part_legal = False
-                for part in csr_search:
-                    (csr, csr_ind, csr_op, csr_vals) = part
-                    msb = int(csr_ind.split(':')[0])
-                    lsb = int(csr_ind.split(':')[-1])
-                    bitmask = True if 'bitmask' in csr_op else False
-                    trunc_val = int(bin(value)[2:].zfill(64)[::-1][lsb:msb+1][::-1],base=2)
+    def check_subval_legal(self, legalstr, value):
+        """This function checks if a given value satifies the conditions present
+        in a given legal string.
 
-                    if not bitmask: # if its not a bitmask
-                        if ":" in csr_vals: # range is specified
-                            [base, bound] = csr_vals.split(':')
-                            base = int(base, 0)
-                            bound = int(bound, 0)
-                            if trunc_val >= base and trunc_val <= bound: # check legal range
-                                part_legal = True
-                        else:
-                            l_vals = csr_vals.split(',')
-                            legal_vals = []
-                            for i in l_vals : 
-                                legal_vals.append(int(i,0))
-                            if trunc_val in legal_vals:
-                                part_legal = True
-                    else: # in case of bitmask there are no illegal values
-                        part_legal = True
-                    if not part_legal:
-                        break
-                if part_legal and dep_satified:
-                    is_legal = True
-                
-        return is_legal
+        :param legalstr: This is a string following the warl-legal syntax.
+        :type legalstr: str
+        :param value: The value whose legality to be checked against the
+            warl-legal string
+        :type value: int
+        :return: A list of error strings encountered while performing the 
+            checks on a legal string
+        :rtype: list(str)
 
-    def update(self, curr_val, wr_val, dependency_vals=[]):
-        ''' The function takes the current value, write value and an optional list(optional incase there are no dependencies) containing the
-        values of the corresponding dependency fields and models the updation of
-        the register i.e if the supplied value is legal then the value is returned, else the new value of
-        the register is calculated and returned.
-        '''
-        flag1 = 0
-        flag2 = 0
-        flag3 = 0
-        flag4 = 0
-        j = 0
-        if self.dependencies != [] and dependency_vals != []:
-            for i in range(len(self.warl['legal'])):
-                mode1 = re.findall('\[(\d)\]\s*->\s*', self.warl['legal'][i])
-                for i1 in range(len(dependency_vals)):
-                    if dependency_vals[i1] == int(mode1[i1]):
-                        j = i
-                        flag1 = 1
-                        break
-            if flag1 == 0:
-                print("Dependency vals do not match")
-                exit()
-        else:
-            if len(self.warl['legal']) != 1:
-                print("There cannot be more than one legal value")
-                exit()
+        The legal string is first broken down into smaller substrings, each of
+        which assigns certain bits a specific value. Each substring should match
+        the following regular-expression: ``\[(.*?)\]\s*(bitmask|in|not in)\s*\[(.*?)\]``
+
+        For each substring, we then extract the indicies of the csr/subfield
+        that are being assigned, the operation used (one of `bitmask`, `in` or
+        `not in`) and values being assigned. Using the indices we extract the
+        relevant sub-value of the input value argument which applies to these
+        indices (we refer to this as subval).
+
+        In case of a ``bitmask`` operation all values of the input are considered
+        legal - since the mask and fixedval will ensure only legal values are
+        set.
+
+        In case of an ``in`` operation, the values list (extracted from the
+        substring) is split into individual elements. Each element can either be
+        a range or a single integer. In case of a range we check if the input
+        subval falls within this range or not. In case of a single integer we
+        perform a direct match. We parse the entire values list and stop as soon
+        as atleast on match is detected.
+
+        In case of a ``not in`` operation, the procedure is the same as above,
+        except we parse through the entire values list to ensure the subval
+        doesn't match any of those values, only then the subval is treated as a
+        legal value.
+
+        """
+        assigns = self.regex_legal.findall(legalstr)
+        err = []
+        for a in assigns:
+            (indices, op, vals) = a
+            msb = int(indices.split(':')[0], 0)
+            if ':' in indices:
+                lsb = int(indices.split(':')[1], 0)
             else:
-                j = 0
-        inp1 = self.warl['legal'][j]
-        flag1 = 0
-        if self.dependencies != [] and dependency_vals != []:
-            for i in range(len(self.warl['legal'])):
-                if "bitmask" in self.warl['legal'][i]:
-                    flag4 = 1
-                else:
-                    flag4 = 0
-                    break
+                # if its a single value, then lsb and msb are the same
+                lsb = msb
+            bitlen = msb - lsb + 1
 
-            if flag4 == 0 and not "bitmask" in inp1:
-                for i in range(len(self.warl['wr_illegal'])):
-                    mode = re.findall('\[(\d)\]\s*.*->\s*',
-                                      self.warl['wr_illegal'][i])
-                    op = re.findall(r'in\s*\[(.*?)\]',
-                                    self.warl['wr_illegal'][i])
-                    if op != []:
-                        z = re.split("\:", op[0])
-                    for i1 in range(len(dependency_vals)):
-                        if dependency_vals[i1] == int(mode[i1]):
-                            if op != []:
-                                if int(wr_val, 0) in range(int(z[0], 0),
-                                                    int(z[1], 0)):
-                                    j = i
-                                    flag1 = 1
-                                    break
-                            else:
-                                j = i
-                                flag1 = 1
-                                break
-                    if flag1 == 1:
-                        break
-                inp = self.warl['wr_illegal'][j]
-            else:
-                inp = "no value"
-                flag1 = 1
+            # extract the value of the bits for which this particular substring
+            # is applicable.
+            subval = (value >> lsb) & ((1 << bitlen)-1)
+            values = vals.split(',')
 
-        elif self.dependencies == [] and dependency_vals == [] and not "bitmask" in self.warl[
-                'legal'][0]:
-            for i in range(len(self.warl['wr_illegal'])):
-                op = re.findall(r'\s*wr_val\s*in\s*\[(.*?)\]',
-                                self.warl['wr_illegal'][i])
-                if op != []:
-                    z = re.split("\:", op[0])
-                    if int(wr_val, 0) in range(int(z[0], 0), int(z[1], 0)):
-                        j = i
-                        flag1 = 1
-                        break
-
-                else:
-                    j = i
-                    flag1 = 1
-                    break
-
-            inp = self.warl['wr_illegal'][j]
-
-        elif self.dependencies != [] and dependency_vals != [] and len(
-                self.warl['legal']) == 1 and "bitmask" in self.warl['legal'][0]:
-            flag1 = 1
-
-        if flag1 == 0 and dependency_vals != []:
-            print("Dependency vals do not match")
-            exit()
-        if (self.islegal(curr_val, dependency_vals) == False):
-            return "Current value must be legal"
-        if (self.islegal(wr_val, dependency_vals)):
-            return wr_val
-        elif not "bitmask" in inp1:
-            if "->" in inp:
-                op2 = re.split(r'\->', inp)
-                wr = op2[1]
-            else:
-                wr = inp.strip()
-            if "0x" in wr:
-                return wr.strip()
-            elif wr.lower().strip() == "unchanged":
-                return ("0x" + curr_val)
-
-            elif wr.lower().strip() == "nearup":
-                a = []
-                flag2 = 0
-                l = self.legal(dependency_vals)
-                for i in range(len(l)):
-                    if len(l[i]) == 1:
-                        a.append(abs(int(wr_val, 0) - int(l[i][0], 0)))
-                for i in range(len(a) - 1, -1, -1):
-                    if a[i] == min(a):
-                        j = i
-                        flag2 = 1
-                        break
-                if flag2 == 1:
-                    return l[j][0]
-
-            elif wr.lower().strip() == "neardown":
-                a = []
-                l = self.legal(dependency_vals)
-                for i in range(len(l)):
-                    if len(l[i]) == 1:
-                        a.append(abs(int(wr_val, 0) - int(l[i][0], 0)))
-                for i in range(len(a)):
-                    if a[i] == min(a):
-                        j = i
-                        flag2 = 1
-                        break
-                if flag2 == 1:
-                    return l[j][0]
-
-            elif wr.lower().strip() == "nextup":
-                l = self.legal(dependency_vals)
-                for i in range(len(l)):
-                    if int(l[i][0], 0) > int(wr_val, 0) and len(l[i]) == 1:
-                        j = i
-                        flag2 = 1
-                        break
-                if flag2 == 1:
-                    return l[j][0]
-                else:
-                    return max(l)
-
-            elif wr.lower().strip() == "nextdown":
-                l = self.legal(dependency_vals)
-                for i in range(len(l)):
-                    if int(l[i][0], 0) > int(wr_val, 0) and len(l[i]) == 1:
-                        j = i
-                        flag2 = 1
-                        break
-                if flag2 == 1 and j != 0:
-                    return l[j - 1][0]
-                else:
-                    return min(l)
-
-            elif wr.lower().strip() == "max":
-                flag3 = 0
-                l = self.legal(dependency_vals)
-                for i in range(len(l)):
-                    if "," in l[i][0]:
-                        flag3 = 1
-                        j = i
+            # for `in` atleast one of the vals must be a hit. If none is a hit,
+            # then the value is illegal.
+            if op == 'in':
+                atleast_one_pass = False
+                for v in values:
+                    base = int(v.split(':')[0], 0)
+                    if ':' in v:
+                        bound = int(v.split(':')[1], 0)
                     else:
-                        flag3 = 0
-                if flag3 == 0:
-                    return max(l)
-                else:
-                    y = re.split(",", l[j][0])
-                    return y[1]
-
-            elif wr.lower().strip() == "min":
-                flag3 = 0
-                l = self.legal(dependency_vals)
-                for i in range(len(l)):
-                    if "," in l[i][0]:
-                        flag3 = 1
-                        j = i
-                    else:
-                        flag3 = 0
-                if flag3 == 0:
-                    return min(l)
-                else:
-                    y = re.split(",", l[j][0])
-                    return y[0]
-
-            elif wr.lower().strip() == "addr":
-                wr = format(int(wr_val, 0),
-                            '#0{}b'.format(4 * self.bitsum + 2))
-                wr = wr[2:]
-                if wr[0:1] == '0':
-                    wr_final = '1' + wr[1:]
-                elif wr[0:1] == '1':
-                    wr_final = '0' + wr[1:]
-                else:
-                    print("Invalid binary bit")
-                return hex(int(wr_final, 0))
-
-            else:
-                return "Invalid update mode"
-
-        else:
-            x = re.findall(
-                r'\s*.*\s*\[.*\]\s*{}\s*\[(.*?,.*?)\]'.format("bitmask"), inp1)
-            z = re.findall(
-                r'\s*.*\s*\[(.*)\]\s*{}\s*\[.*?,.*?\]'.format("bitmask"), inp1)
-            y = re.split("\,", x[0])
-            bitmask = int(y[0], 0)
-            fixedval = int(y[1], 0)
-            currval = int(wr_val, 0)
-            legal = ((currval & bitmask) | fixedval)
-            return hex(legal)
-
-    def legal(self, dependency_vals=[]):
-        '''The function takes a range(defined as a 2 tuple list) and an optional(optional incase there are no dependencies) list containing the
-        values of the corresponding dependency fields and returns the set of legal values as a list of two tuple lists.
-        '''
-        flag1 = 0
-        j = 0
-        if self.dependencies != [] and dependency_vals != []:
-            for i in range(len(self.warl['legal'])):
-                mode = re.findall('\[(\d)\]\s*->\s*', self.warl['legal'][i])
-                for i1 in range(len(dependency_vals)):
-                    if dependency_vals[i1] == int(mode[i1]):
-                        j = i
-                        flag1 = 1
+                        bound = base
+                    if subval >= base and subval <= bound:
+                        atleast_one_pass = True
                         break
-                if flag1 == 1:
+                if not atleast_one_pass:
+                    err.append(f' for csr "{self.csrname}" and warl \
+sub-string "{legalstr}" the value "{hex(value)}" is not legal since it fails the condition \
+"[{indices}] {op} [{vals}]"')
                     break
-            if flag1 == 0 and dependency_vals != []:
-                print("Dependency vals do not match")
-                exit()
-        else:
-            if len(self.warl['legal']) != 1:
-                print("There cannot be more than one legal value")
-                exit()
+            # for `not in` even a single match will treat the value as illegal.
+            elif op == 'not in':
+                all_pass = True
+                for v in values:
+                    base = int(v.split(':')[0], 0)
+                    if ':' in v:
+                        bound = int(v.split(':')[1], 0)
+                    else:
+                        bound = base
+                    if subval >= base and subval <= bound:
+                        all_pass = False
+                if not all_pass:
+                    err.append(f' for csr "{self.csrname}" and warl \
+sub-string "{legalstr}" the value "{value}" is not legal since it fails the condition \
+"[{indices}] {op} [{vals}]"')
+                    break
+            # for bitmask all values are treated as legal.
+            elif op == 'bitmask':
+                continue
             else:
-                j = 0
-        inp = self.warl['legal'][j]
-        s = re.findall(r'in\s*\[(.*?)\]', inp)
-        a = []
-        b = []
-        tup = []
-        for i in range(len(s)):
-            tup = []
-            if ":" in s[i]:
-                tup.append(s[i].replace(":", ","))
-                a.append(tup)
+                err.append(f' found op:"{op}" in legal string :"{legalstr}" \
+which is not supported')
+                break
 
-            else:
-                tup = []
-                tup.append(s[i])
-                a.append(tup)
-        if not "bitmask" in inp:
-            w = re.split(",", a[0][0])
-            o = []
-            for i in range(len(w)):
-                e = w[i].strip().split()
-                o.append(e)
-            o.sort()
-            return o
+        return err
+
+    def islegal(self, value, dependency_vals=None):
+        """This function is used to check if an input value is a legal value for
+        csr for given set of dependency values. The legality is checked against
+        all warl string listed under the `legal` node of the warl dictionary.
+
+        :param value: input integer whose legality needs to be checked for the
+            csr/subfield warl node.
+        :type value: int
+        :param dependency_vals: This is dictionary of csr:value pairs which
+            indicates the current value of csrs/subfields present in the
+            dependency_fields of the warl node.
+        :type dependency_vals: dict
+
+        If the dependency_fields of the warl node is empty, then the single
+        legal string in the legal list, is simply processed by the function
+        :py:func:`check_subval_legal` and result of which is simply returned as
+        is.
+
+        However, if the dependency_fields is not empty, then for each legal 
+        string we check if both dependency_vals substring is satisfied and the
+        assignment substring is also satisfied, else an error is generated.
+
+        for the dependency_vals substring the values of the csrs in the 
+        dependency_fields if obtained either from the input dependency_vals
+        argument or else the reset-vals of the csr in the isa spec (self.spec)
+        are used. If neither is available, then an error is posted about the
+        same.
+
+        The dependency_vals substring is again split further down to process
+        each condition individually. The checks for the dependency_vals 
+        substring include: 
+
+            - checking is the csrs in the substring are indeed present in the
+              dependency_fields list of the warl node
+            - if writeval or currval is detected, then that part of the
+              conditions is ignored.
+
+        The dependency_vals substring is treated as a boolean condition. Hence,
+        when when each part of the substring is evaluated, we replace that part
+        of the string with either True or False, and at the end perform an
+        `eval` on the new replaced dependency_vals substring. If this condition
+        evaluates to True, the corresponing assign string also evaluates to
+        True, then the input value is considered legal.
+
+        Things this function does not do:
+            
+            - this does not check if the warl strings are valid. It is assumed
+              that they are valid. If not, pass them through the function iserr
+              to check for validity.
+            - in case of dependency_fields being not empty, this function
+              doesn't check if the possible values of the dependency
+              csrs/subfields are indeed legal for them. This causes a nesting
+              problem, which is probably doesn't warrant an immediate solution ??
+            - 
+        """
+        logger.debug(f'---- WARL Value Legality Check: value:{value} csr:{self.csrname} dependency_vals:{dependency_vals}')
+        err = []
+        # if no dependencies then only one legal string is present. Simply use
+        # check_subval_legal function to detect legality.
+        if not self.dependencies:
+            for legalstr in self.node['legal']:
+                err = self.check_subval_legal(legalstr, value)
+        # in case of dependencies there can be multiple legal strings. We split
+        # the legal strings into dependency strings and assign strings. Each
+        # substring needs to be validated to indicate that value is indeed legal
+        # for the current set of dependency vals.
         else:
-            return a
-#str1=\
-#'''
-#dependency_fields: []
-#legal:
-#  - "extensions[7:4] in [1,3,5] extensions[3:0] in [0x0:0xF]"
-#wr_illegal:
-#  - "Unchanged"
-#'''
-#
-#str2=\
-#'''
-#dependency_fields: []
-#legal:
-#  - "asid[8:0] in [0x00:0x1FF]"
-#wr_illegal:
-#  - Unchanged
-#'''
-#
-#node = yaml.load(str2)
-#warl = warl_interpreter(node)
-#print(str(warl.islegal(0xFFFF, [])))
+            for legalstr in self.node['legal']:
+                depstr = legalstr.split('->')[0]
+                # we replace all boolean operators first to simple parse and the
+                # check if the (in|not in|bitmask) operators are infact legal or
+                # not.
+                raw_depstr = re.sub('\(|\)|and|or','',depstr)
+
+                # implicitly assume it passes - in case of writeval and currval.
+                dep_pass = True
+                for m in self.regex_dep_legal.finditer(raw_depstr):
+                    (csrname, indices, op, vals) = m.groups()
+                    matchstr = m.group()
+
+                    # in case the dependency is on writeval then we
+                    # assume the condition is always true.
+                    if csrname in ['writeval']:
+                        depstr = depstr.replace(matchstr, 'True')
+                        continue
+                    # in case the dependency is on the current val of the same
+                    # csr (before performing the write), then we continue by
+                    # replacing the currval string with the csrname::subfield
+                    # syntax
+                    if csrname == 'currval':
+                        if '::' in self.csrname:
+                            renamed_csr = self.csrname.split('::')[0]
+                            subfield = self.csrname.split('::')[1]
+                        else:
+                            renamed_csr = self.csrname
+                            subfield = ''
+                    else:
+                        renamed_csr = list(filter(re.compile(f'[a-zA-Z0-9]*[:]*{csrname}\s*$').match, self.dependencies))[0]
+                        if '::' in renamed_csr:
+                            subfield = renamed_csr.split('::')[1]
+                        else:
+                            subfield = ''
+                        renamed_csr = renamed_csr.split('::')[0]
+                    # if the dependency_vals dict is not empty, then pick the
+                    # values of the csrs/subfields from there. Here we expect
+                    # the key in the dependency_vals dict to be a subfield
+                    # name without the `::` delimiter.
+                    if dependency_vals is not None:
+                        if csrname not in dependency_vals:
+                            err.append(f'in warl string of {self.csrname}, \
+the value of dependency field {csrname} not present in dependency_vals')
+                            return err
+                        else:
+                            dep_csr_val = dependency_vals[csrname]
+                    # else we pick the reset-vals from the isa spec (if the isa
+                    # spec was provided during contruction of the class). If the
+                    # dependency field is a subfield, then the reset-val of the
+                    # subfield has to be extracted from the reset-val of the csr
+                    elif self.spec is not None:
+                        dep_csr_val = self.spec[renamed_csr]['reset-val']
+                        if subfield != '':
+                            msb = self.spec[renamed_csr][self.isa][subfield]['msb']
+                            lsb = self.spec[renamed_csr][self.isa][subfield]['lsb']
+                            bitlen = msb - lsb + 1
+                            dep_csr_val = (dep_csr_val >> lsb) & \
+                                ((1 << bitlen)-1)
+                    else:
+                        err.append(f'No dependency_vals or spec exists to \
+check the values of the csrs in the dependency_fields of csr {self.csrname}')
+                        return err
+
+                    step_err = self.check_subval_legal(matchstr, dep_csr_val)
+                    err = err + step_err
+                    step_pass = True if step_err == [] else False
+                    depstr = depstr.replace(matchstr, str(step_pass))
+                dep_pass = eval(depstr)
+
+                assignstr = legalstr.split('->')[1]
+                assign_err = self.check_subval_legal(assignstr, value)
+                err = err + assign_err
+                assign_legal = True if assign_err == [] else False
+                # if at any point both dependency strings and the assign strings
+                # pass, then throw away the errors and treat it as a pass.
+                if assign_legal and dep_pass:
+                    logger.debug(f' warl legal string "{legalstr}" treats the \
+input value {value} as legal')
+                    err = []
+                    break
+        return err
+
+    def iserr(self):
+        csrname = self.csrname
+        reg_lsb = 0
+        if self.f_lsb != 0:
+            reg_msb = self.f_msb - self.f_lsb
+        else:
+            reg_msb = self.f_msb
+        reg_bitlen = reg_msb - reg_lsb + 1
+        reg_maxval = 2**reg_bitlen
+        err = []
+        #basic checks
+        #if dependencies is empty, then there should be only one legal string
+        if self.dependencies == [] and len(self.node['legal']) > 1:
+            err.append(f'for In absence of dependencies there should be only \
+1 legal string, instead found {len(self.node["legal"])}')
+        if err:
+            return err
+
+        # start checking legality of all legal strings
+        for legalstr in self.node['legal']:
+            depstr = legalstr.split('->')[0]
+            raw_depstr = re.sub('\(|\)|and|or','',depstr)
+            dep_str_matches = self.regex_dep_legal.findall(raw_depstr)
+
+            # if there are no dependencies then "->" should never be used in the
+            # warl legal strings
+            if '->' in legalstr and self.dependencies == []:
+                err.append(f' found "->" in legal string "legalstr" when \
+dependency_fields is empty.')
+                return err
+            if self.dependencies != [] and not '->' in legalstr:
+                err.append(f' missing "->" in legalstr since dependency_fields \
+is non empty')
+                return err
+
+            if '->' in legalstr:
+                dependencies = self.node['dependency_fields']
+                if dependencies != [] and self.spec is not None:
+                    for d in dependencies:
+                        subfield = ''
+                        if '::' in d:
+                            depcsrname = d.split('::')[0]
+                            subfield = d.split('::')[1]
+                        else:
+                            depcsrname = d
+                        # if the dependency is on writeval or currval of the
+                        # same csr, then no more checks required.
+                        if depcsrname not in ['writeval', 'currval']:
+                            # if the csr doesn't exist then its probably a typo
+                            if depcsrname not in self.spec:
+                                err.append(f' warl for csr {csrname} depends on csr \
+{depcsrname} is not a valid csrname as per spec')
+                            # if csr exists, but is not accessible, then its a
+                            # pointless dependency
+                            elif not self.spec[depcsrname][self.isa]['accessible']:
+                                err.append(f' warl for csr {csrname} depends on csr \
+{depcsrname} is not accessible or not implemented in the isa yaml')
+                            # if csr exists and is accessible but subfield
+                            # doesn't exist, then its another typo
+                            elif subfield != '' and subfield not in self.spec[depcsrname][self.isa]:
+                                err.append(f' warl for csr {csrname} depends on \
+subfield {depcsrname}::{subfield} which does not exist as per spec')
+                            # if subfield is valid, but is not implemented, then
+                            # its another pointless dependency
+                            elif not self.spec[depcsrname][self.isa][subfield]['implemented']:
+                                err.append(f' warl for csr {csrname} depends \
+on subfield {depcsrname}::{subfield} which is not implemented')
+
+                    # ensure that all dependency csrs/subfields found in the
+                    # strings, are indeed present in the dependency_fields list
+                    # of the warl node.
+                    for matches in dep_str_matches:
+                        (csr, ind, op, val) = matches
+                        csr_in_dependencies = list(filter(re.compile(f'[a-zA-Z0-9]*[:]*{csr}\s*$').match, dependencies))
+                        if csr_in_dependencies == []:
+                            err.append(f' dependency_vals string "{depstr}" for csr \
+{csrname} is dependent on field {csr} which is not present in the \
+dependency_fields list of the node')
+
+                for matches in dep_str_matches:
+                    (csr, indices, op, val) = matches
+                    # only in and not-in are supported inside dependency
+                    # strings. Bitmask do not make sense as a boolean operation.
+                    if op not in ['in', 'not in']:
+                        err.append(f' the dependency_vals string {depstr} for csr \
+{csr} uses operation "{op}" which is not supported. Use only "in" and "not in" \
+operations only')
+
+                    msb = int(indices.split(':')[0], 0)
+                    if ':' in indices:
+                        lsb = int(indices.split(':')[1], 0)
+                    else:
+                        lsb = msb
+                    # for range value strings, indices msb::lsb syntax to be 
+                    # followed where msb > lsb
+                    if msb < lsb:
+                        err.append(f'msb < lsb for one of the \
+dependency_vals in warl string {legalstr} in csr {csrname}')
+                    maxval = 2**(msb - lsb + 1 )
+                    values = val.split(',')
+
+                    # for each range value, check if the base and bound are
+                    # correctly ordered and within the possible values of the
+                    # csr/subfield
+                    for v in values:
+                        base = int(v.split(':')[0], 0)
+                        if ':' in v:
+                            bound = int(v.split(':')[1], 0)
+                        else:
+                            bound = base
+                        if base >= maxval or bound >= maxval:
+                            err.append(f'The range values in dependency_vals of warl\
+ string "{legalstr}" for csr {csrname} are out of bounds wrt the indices used \
+in that string')
+                        if base > bound:
+                            err.append(f' base > bound for range \
+values in dependency_vals of the warl string "{legalstr}" for csr {csrname}')
+
+            lstr = legalstr.split('->')[-1]
+            bitcount = reg_bitlen
+
+            assigns = self.regex_legal.findall(lstr)
+            # if there is not match, then something is wrong in the string.
+            if assigns == []:
+                err.append(f' The legal string "{legalstr}" for csr \
+{csrname} does not follow warl syntax')
+            # split the assignment string and process each individually.
+            for a in assigns:
+                (indices, op, vals) = a
+
+                # msb lsb checks just as before 
+                msb = int(indices.split(':')[0], 0)
+                if ':' in indices:
+                    lsb = int(indices.split(':')[1], 0)
+                else:
+                    lsb = msb
+                if msb < lsb:
+                    err.append(f'msb < lsb for one of the \
+range values in warl string {legalstr} in csr {csrname}')
+                if msb > reg_msb or lsb < reg_lsb:
+                    err.append(f' The indices used in warl \
+string "{legalstr}" of csr {csrname} do not comply with the msb[{reg_msb}] and lsb[{reg_lsb}] values \
+of the register')
+
+                # we need to ensure that the assignment string eventually
+                # defines the legal value for all the bits (and not just a few).
+                # To check this we use a counter (bitcount) which is initialized
+                # to the size of the register/subfield. And each time a part of
+                # the assignment string is evaluated, we decrease the bitcount
+                # by the size of the assigment. At the end, if the bitcount is
+                # not zero then there is something wrong in the entire
+                # assignment string.
+                bitcount = bitcount - (msb-lsb+1)
+                bitlength = msb - lsb + 1
+                maxval = 2**bitlength
+                if op not in ['in', 'not in', 'bitmask']:
+                    err.append(f' the warl string {legalstr} for csr \
+{csr} uses operation "{op}" which is not supported. Use only "in", "bitmask" and "not in" \
+operations only')
+                if 'bitmask' in op:
+                    if len(vals.split(',')) != 2:
+                        err.append(f'bitmask syntax is wrong in legal string \
+{legalstr}')
+                        break
+                    mask = int(vals.split(',')[0], 0)
+                    fixedval = int(vals.split(',')[1], 0)
+                    if mask > reg_maxval or fixedval > reg_maxval:
+                        err.append(f' The mask and/or fixedval used in \
+bitmask string "{legalstr}" of csr {csrname} have values exceeding the \
+maxvalue the csr can take.')
+                else:
+                    values = vals.split(',')
+                    for v in values:
+                        base = int(v.split(':')[0], 0)
+                        if ':' in v:
+                            bound = int(v.split(':')[1], 0)
+                        else:
+                            bound = base
+                        if base >= maxval or bound >= maxval:
+                            err.append(f'The range values in warl \
+string "{legalstr} for csr {csrname} are out of bounds wrt the indices used \
+in that string')
+                        if base > bound:
+                            err.append(f' base > bound for range \
+values in warl string "{legalstr}" for csr {csrname}')
+           
+            if bitcount < 0:
+                err.append(f' warl string {legalstr} defines values for bits \
+outside the size of the register {reg_bitlen}')
+            elif bitcount != 0:
+                err.append(f' warl string {legalstr} for csr \
+{csrname} either does not define values for all bits or has overlapping ranges \
+defining the same bits multiple times')
+
+        return err
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.17.0
+current_version = 3.0.0
 commit = True
 tag = True
 


### PR DESCRIPTION
  - created new warl class for warl node handling
    - better comments
    - more functions to keep things simple
    - fixed a lot of bugs in checking legal values
    - bitmask and range values can now co-exist in a legal string
    - added new and improved checks for syntax validity of warl strings
  - fixed validationError function to correctly print all errors (dict and/or list)
  - removed wr\_illegal checks from the schema since they are now done as part of the new warl class
    checks
  - updates to the new warl checks and reset-value checks
  - satp.mode should have one of sv\* translation schemes as a legal value. (#89)
  - default setters for pmps fixed
  - pmp checks have been improved (close #88)
  - improve WARL documentation