### PR TITLE
minor fixes in checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [3.9.1] - 2023-06-21
   - Check if YAMLs are None before they're merged for performing CSR checks.
+  - Perform XLEN specific satp checks based on XLEN value.
+  - Check triggers only when debug CSRs are available.
 
 ## [3.9.0] - 2023-05-06
   - Add support to include hidden uarch dependencies in YAML definitions of CSRs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.1] - 2023-06-21
+  - Check if YAMLs are None before they're merged for performing CSR checks.
+
 ## [3.9.0] - 2023-05-06
   - Add support to include hidden uarch dependencies in YAML definitions of CSRs.
   - Perform checks on all CSRs together instead of handling each spec seperately.

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.9.0'
+__version__ = '3.9.1'

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -1359,8 +1359,8 @@ def check_supervisor(spec, logging=False):
         for x in [1,2,3,4,5,6,7,11,12,13]:
             err = warl_inst.islegal(x)
             if not err:
-                errors.append(f'warl function for satp::mode accepts \
-"{x}" as a legal value - which is incorrect')
+                errors['satp_mode_checks'] = f'warl function for satp::mode accepts \
+"{x}" as a legal value - which is incorrect'
         warl_inst = warl_class(satp_mode_type['warl'], 'satp::mode', msb, lsb, spec)
         for x in virt_modes:
             err = warl_inst.islegal(x)

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -2038,8 +2038,10 @@ def check_csr_specs(ispec=None, customspec=None, dspec=None, pspec=None, work_di
         hart_ids.append(entry)
         merged[entry] = {}
         merged[entry].update(ispec_dict['hart'+str(entry)])
-        merged[entry].update(customspec_dict['hart'+str(entry)])
-        merged[entry].update(dspec_dict['hart'+str(entry)])
+        if custom_file is not None:
+            merged[entry].update(customspec_dict['hart'+str(entry)])
+        if debug_file is not None:
+            merged[entry].update(dspec_dict['hart'+str(entry)])
 
         try:
             uarch_signals = merged[entry]['uarch_signals']

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -1355,12 +1355,14 @@ def check_supervisor(spec, logging=False):
         else:
             virtualization_possible = True
     elif 'warl' in satp_mode_type:
-        warl_inst = warl_class(satp_mode_type['warl'], 'satp::mode',63, 60)
-        for x in [1,2,3,4,5,6,7,11,12,13]:
-            err = warl_inst.islegal(x)
-            if not err:
-                errors['satp_mode_checks'] = f'warl function for satp::mode accepts \
-"{x}" as a legal value - which is incorrect'
+        # these are the checks from _check_with_satp_modes64
+        if xlen == 64:
+            warl_inst = warl_class(satp_mode_type['warl'], 'satp::mode',63, 60)
+            for x in [1,2,3,4,5,6,7,11,12,13]:
+                err = warl_inst.islegal(x)
+                if not err:
+                    errors['satp_mode_checks'] = f'warl function for satp::mode accepts \
+    "{x}" as a legal value - which is incorrect'
         warl_inst = warl_class(satp_mode_type['warl'], 'satp::mode', msb, lsb, spec)
         for x in virt_modes:
             err = warl_inst.islegal(x)

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -2095,7 +2095,11 @@ def check_csr_specs(ispec=None, customspec=None, dspec=None, pspec=None, work_di
 
         if logging:
             logger.info(f'Initiating validation checks for trigger csrs')
-        errors = check_triggers(csr_db, logging)
+        if dspec_dict == {}:
+            if logging:
+                logger.warning(f'No debug spec passed. Skipping trigger checks.')
+        else:
+            errors = check_triggers(csr_db, logging)
         if errors:
             raise ValidationError("Error in csr definitions", errors)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.9.0
+current_version = 3.9.1
 commit = True
 tag = True
 


### PR DESCRIPTION
## [3.9.1] - 2023-06-21
  - Check if YAMLs are None before they're merged for performing CSR checks.
  - Perform XLEN specific satp checks based on XLEN value.
  - Check triggers only when debug CSRs are available.