### PR TITLE
Include additional S_extensions: s*clint, s*clic, s*csrind

### DIFF
--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -32,7 +32,7 @@ Z_extensions = [
         "Zpn", "Zpsf"
 ] + Zve_extensions + Zvl_extensions
 
-S_extensions = ['Smrnmi','Svnapot','Svadu']
+S_extensions = ['Smrnmi','Svnapot','Svadu','Smcsrind','Sscsrind','Smclint','Ssclint','Smclic','Ssclic','Smclicshv']
 
 sub_extensions = Z_extensions + S_extensions
 


### PR DESCRIPTION
Adding additional S_extensions: 'Smcsrind','Sscsrind','Smclint','Ssclint','Smclic','Ssclic','Smclicshv'

<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Provide a detailed description of the changes performed by the PR.

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist.

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Mandatory Checklist:

  - [ ] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [ ] Make sure to have created a suitable entry in the CHANGELOG.md.
