### PR TITLE
Fix satp checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.2] - 2023-09-20
+  - Perform satp checks only when the CSR is accessible.
+
 ## [3.13.1] - 2023-08-21
   - Add support for Code Size Reduction (Zce) extension
 

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.13.1'
+__version__ = '3.13.2'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.13.1
+current_version = 3.13.2
 commit = True
 tag = True
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

This PR changes the supervisor checks. ``satp.mode`` checks will now only happen if the CSR is accessible.

### Related Issues

Resolves issue #144

### Update to/for Ratified/Unratified Extensions 

- [x] Ratified
- [ ] Unratified

### List Extensions

S - Supervisor

### Mandatory Checklist:

  - [x] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
