### PR TITLE
PMP grain checks for WARL definitions of pmpaddr CSRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.0] - 2023-09-21
+  - Added PMP grain checks for warl definitions of accessible pmpaddr CSRs.
+  - Moved redundant uarch logging to debug verbosity level.
+
 ## [3.13.2] - 2023-09-20
   - Perform satp checks only when the CSR is accessible.
 

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.13.2'
+__version__ = '3.14.0'

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -1521,7 +1521,7 @@ pmp*cfg registers [{pmpcfg_count}] do not match']
                         elif entry[0][1] == 'in':
                             warl_values.extend(entry[0][2])
                         for warl_value in warl_values:
-                            writeval = (bin(int(warl_value, base=16))[2:].zfill(32))[::-1]
+                            writeval = (bin(int(warl_value[2:], base=16))[2:].zfill(32))[::-1]
                             try:
                                 pmp_legal = False if (writeval[xlen-Grain] != '0') else True
                             except IndexError as err:

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -1519,7 +1519,11 @@ pmp*cfg registers [{pmpcfg_count}] do not match']
                         elif entry[0][1] == 'not in':
                             logger.warning(f'warl definition for {csrname} will not be checked as the search space is too large.')
                         elif entry[0][1] == 'in':
-                            warl_values.extend(entry[0][2])
+                            if ':' in entry[0][2]:
+                                warl_values.append(entry[0][2].split(':')[0])
+                                warl_values.append(entry[0][2].split(':')[1])
+                            else:
+                                warl_values.extend(entry[0][2])
                         for warl_value in warl_values:
                             writeval = (bin(int(warl_value[2:], base=16))[2:].zfill(32))[::-1]
                             try:

--- a/riscv_config/warl.py
+++ b/riscv_config/warl.py
@@ -63,7 +63,7 @@ class warl_class():
             else:
                 self.uarch_signals = {}
         except KeyError:
-            logger.info(f'No uarch_signals found in spec.')
+            logger.debug(f'No uarch_signals found in spec.')
             self.uarch_signals = {}
         self.csrname = csrname
         if spec is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.13.2
+current_version = 3.14.0
 commit = True
 tag = True
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

This PR introduces a new check on the WARL definitions of all accessible ``pmpaddr`` CSRs for coherency with the pmp grain.

These checks are only applicable on the mask if the legality is defined by a ``bitmask``. These checks are applied only to the base and bound values if the warl definition looks for the writeval to be ``in`` a range. These checks are applied to all values if the legality is defined by the writeval being ``in`` a flat list of values. These checks are skipped if the warl definition looks for values ``not in`` a certain list of values.

This PR also changes the verbosity level at which some redundant logger statements for uarch dependency support are printed. 

### Related Issues

Issue #143 
Issue #147 

### Mandatory Checklist:

  - [x] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
