### PR TITLE
 do not assign subfield to None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.3] - 2023-09-23
+  - do not assign subfield to None
+
 ## [3.13.2] - 2023-09-20
   - Perform satp checks only when the CSR is accessible.
 

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.13.2'
+__version__ = '3.13.3'

--- a/riscv_config/warl.py
+++ b/riscv_config/warl.py
@@ -502,19 +502,18 @@ input value {value} as legal')
                             subfield = d.split('::')[1]
                         else:
                             depcsrname = d
-                            subfield = None
 
                         # if the depcsrname has the 'uarch_' prefix, then drop that dependency for all checks entirely
                         if depcsrname.startswith('uarch_'):
-                            subfield_str = '' if subfield is None else f'{subfield} field from '
+                            subfield_str = '' if subfield == '' else f'{subfield} field from '
                             logger.warning(f'WARL for csr {csrname} depends on \
 {subfield_str}uarch csr {depcsrname}. Treating this as a uarch dependency.')
-                            if subfield is None:
+                            if subfield == '':
                                 subfield = depcsrname
                                 depcsrname = 'uarch_signals'
                             if depcsrname not in self.uarch_depends:
                                 self.uarch_depends[depcsrname] = []
-                            if subfield is not None and subfield not in self.uarch_depends[depcsrname]:
+                            if subfield != '' and subfield not in self.uarch_depends[depcsrname]:
                                 self.uarch_depends[depcsrname].append(subfield)
                             logger.debug(f'uArch dependencies are: {self.uarch_depends}')
 
@@ -585,7 +584,6 @@ is non empty')
                             subfield = d.split('::')[1]
                         else:
                             depcsrname = d
-                            subfield = None
 
                         # if the csr is a uarch dependency and also exists in the spec, throw an error
                         if depcsrname in self.uarch_depends and depcsrname in self.spec:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.13.2
+current_version = 3.13.3
 commit = True
 tag = True
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

#126 introduced support for uarch-dependencies - however, the subfield variable in warl_class was assigned to None instead of `''`. This caused a few default checks to fail - leading to false negatives.

This PR fixes that issue by re-assigning subfield to `''` and modifying the checks accordingly.

### Related Issues

None

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [ ] Unratified
- [x] framework

### List Extensions

None

### Mandatory Checklist:

  - [x] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
