### PR TITLE
Add unratified Zicfilp and Zicfiss extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.5] - 2023-11-22
+  - Add support for Zicfilp and Zicfiss extensions
+
+## [3.13.4] - 2023-10-30
+  - Add support for Zabha extension
+
 ## [3.13.4] - 2023-10-30
   - Add support for Zabha extension
 

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.13.4'
+__version__ = '3.13.5'

--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -21,7 +21,7 @@ Zve_extensions = [
 ] + Zvef_extensions + Zved_extensions
 
 Z_extensions = [
-        "Zicbom", "Zicbop", "Zicboz", "Zicntr", "Zicsr", "Zicond", "Zifencei", "Zihintpause", "Zihpm",
+        "Zicbom", "Zicbop", "Zicboz", "Zicntr", "Zicsr", "Zicond", "Zicfilp", "Zicfiss", "Zifencei", "Zihintpause", "Zihpm",
         "Zmmul",
         "Zam", "Zabha", "Zacas",
         "Zca", "Zcb", "Zcf", "Zcd" , "Zcmp", "Zcmt", 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.13.4
+current_version = 3.13.5
 commit = True
 tag = True
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

Add configurations for unratfied Zicfilp and Zicfiss extensions

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist.

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [ X] Unratified

### List Extensions

Zicfilp: https://github.com/riscv/riscv-cfi/blob/main/cfi_forward.adoc
Zicfiss: https://github.com/riscv/riscv-cfi/blob/main/cfi_backward.adoc
### Mandatory Checklist:

  - [X ] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [ X] Make sure to have created a suitable entry in the CHANGELOG.md.
