### PR TITLE
Custom csr fields fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [3.15.0] - 2024-01-01
   - Added function that returns the march and mabi for gcc from a given ISA
+  
+## [3.14.4] - 2023-11-20
+  - use the "hartX" naming for the merged dict
+  - improve logging statements
+  - update the "fields" node of each csr in the normalized custom yaml
+
 
 ## [3.14.3] - 2023-12-01
   - Add support for Zimop extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,14 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.15.0] - 2024-01-01
-  - Added function that returns the march and mabi for gcc from a given ISA
-  
-## [3.14.4] - 2023-11-20
+## [3.16.0] - 2024-01-03
   - use the "hartX" naming for the merged dict
   - improve logging statements
   - update the "fields" node of each csr in the normalized custom yaml
 
-
+## [3.15.0] - 2024-01-01
+  - Added function that returns the march and mabi for gcc from a given ISA
+  
 ## [3.14.3] - 2023-12-01
   - Add support for Zimop extension
 

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,4 +1,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.15.0'
+__version__ = '3.16.0'
 

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -1923,7 +1923,7 @@ def check_custom_specs(custom_spec,
         valid = validator.validate(inp_yaml)
         if valid:
             if logging:
-                logger.info('CustomCheck: No errors for Hart:{x}')
+                logger.info(f'CustomCheck: No errors for Hart:{x}')
         else:
             error_list = validator.errors
             raise ValidationError("CustomCheck: Error in " + foo + ".", error_list)

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -2061,21 +2061,21 @@ def check_csr_specs(ispec=None, customspec=None, dspec=None, pspec=None, work_di
     hart_ids = []
     for entry in ispec_dict['hart_ids']:
         hart_ids.append(entry)
-        merged[entry] = {}
-        merged[entry].update(ispec_dict['hart'+str(entry)])
+        merged[f'hart{entry}'] = {}
+        merged[f'hart{entry}'].update(ispec_dict['hart'+str(entry)])
         if custom_file is not None:
-            merged[entry].update(customspec_dict['hart'+str(entry)])
+            merged[f'hart{entry}'].update(customspec_dict['hart'+str(entry)])
         if debug_file is not None:
-            merged[entry].update(dspec_dict['hart'+str(entry)])
+            merged[f'hart{entry}'].update(dspec_dict['hart'+str(entry)])
 
         try:
-            uarch_signals = merged[entry]['uarch_signals']
+            uarch_signals = merged[f'hart{entry}']['uarch_signals']
         except KeyError as e:
-            logger.info("No uarch signals found for hart"+str(entry))
+            logger.info(f"No uarch signals found for hart:{entry}")
             uarch_signals = {}
-
+    
     for entry in hart_ids:
-        csr_db = merged[entry]
+        csr_db = merged[f'hart{entry}']
         if logging:
             logger.info(f"Initiating WARL legality checks for hart:{entry}.")
         errors = check_warl_legality(csr_db, logging)

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -1916,7 +1916,6 @@ def check_custom_specs(custom_spec,
     validator.allow_unknown = True
 
     outyaml = copy.deepcopy(master_custom_yaml)
-    normalized = {}
     for x in master_custom_yaml['hart_ids']:
         if logging:
             logger.info(f'CustomCheck: Processing Hart:{x}')
@@ -1927,8 +1926,12 @@ def check_custom_specs(custom_spec,
                 logger.info('CustomCheck: No errors for Hart:{x}')
         else:
             error_list = validator.errors
-            raise ValidationError("Error in " + foo + ".", error_list)
-        normalized[f'hart{x}'] = validator.normalized(inp_yaml, schema_yaml)
+            raise ValidationError("CustomCheck: Error in " + foo + ".", error_list)
+        normalized = validator.normalized(inp_yaml, schema_yaml)
+        if logging:
+            logger.info(f'CustomCheck: Updating fields node for each CSR Hart:{x}')
+        normalized = update_fields(normalized, logging)
+        outyaml['hart'+str(x)] = trim(normalized)
     errors = check_fields(inp_yaml)
     if errors:
             raise ValidationError("Error in " + foo + ".", errors)

--- a/riscv_config/warl.py
+++ b/riscv_config/warl.py
@@ -63,7 +63,6 @@ class warl_class():
             else:
                 self.uarch_signals = {}
         except KeyError:
-            logger.info(f'No uarch_signals found in spec.')
             self.uarch_signals = {}
         self.csrname = csrname
         if spec is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.15.0
+current_version = 3.16.0
 commit = True
 tag = True
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

  - use the "hartX" naming for the merged dict
  - improve logging statements
  - update the "fields" node of each csr in the normalized custom yaml
  
### Related Issues

NA

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [ ] Unratified
- [x] Neither

### List Extensions

Affects custom CSR checks only.

### Mandatory Checklist:

  - [x] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
