### PR TITLE
Added function that returns the march and mabi for gcc from a given ISA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.15.0] - 2024-01-01
+  - Added function that returns the march and mabi for gcc from a given ISA
 
 ## [3.14.3] - 2023-12-01
   - Add support for Zimop extension

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,4 +1,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.14.3'
+__version__ = '3.15.0'
 

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -185,10 +185,30 @@ def get_march_mabi (isa : str):
 
     march = march.lower()
 
-    march = march.replace('smrnmi_', '')    # remove smrnmi
-    march = march.replace('sdext_',  '')    # remove sdext
-    march = march.replace('zicntr_', '')    # remove zicntr
-    march = march.replace('zihpm_',  '')    # remove zihpm
+    # extensions to be nullified
+    null_ext = [
+        # rnmi
+        'smrnmi_',
+
+        # debug mode
+        'sdext_',
+
+        # performance counter
+        'zicntr_',
+        'zihpm_',
+        
+        # unratified Zb* extensions
+        'zbe_',
+        'zbf_',
+        'zbm_',
+        'zbr_',
+    ]
+
+    # nullify all extensions present in null_ext
+    for each in null_ext:
+        march = march.replace(each, '')
+
+    # handle special cases here
 
     # remove zbp and zbt if zbpbo is present
     if 'zbpbo_' in march:

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -217,6 +217,7 @@ def get_march_mabi (isa : str):
     # construct march
     for ext in ext_list:
         if ext not in null_ext:
+            # suffix multicharacter extensions with '_' 
             if len(ext) == 1:
                 march += ext.lower()
             else:

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -187,33 +187,42 @@ def get_march_mabi (isa : str):
 
     # extensions to be nullified
     null_ext = [
+        # privilege modes
+        'U',
+        'S',
+
         # rnmi
-        'smrnmi_',
+        'Smrnmi',
 
         # debug mode
-        'sdext_',
+        'Sdext',
 
         # performance counter
-        'zicntr_',
-        'zihpm_',
+        'Zicntr',
+        'Zihpm',
         
         # unratified Zb* extensions
-        'zbe_',
-        'zbf_',
-        'zbm_',
-        'zbr_',
+        'Zbe',
+        'Zbf',
+        'Zbm',
+        'Zbr',
     ]
 
-    # nullify all extensions present in null_ext
-    for each in null_ext:
-        march = march.replace(each, '')
+    # add Zbp and Zbt to null_ext if Zbpbo is present
+    if 'Zbpbo' in ext_list:
+        null_ext += ['Zbp', 'Zbt']
 
-    # handle special cases here
-
-    # remove zbp and zbt if zbpbo is present
-    if 'zbpbo_' in march:
-        march = march.replace('zbp_', '')
-        march = march.replace('zbt_', '')
+    # construct march
+    for ext in ext_list:
+        if ext not in null_ext:
+            if len(ext) == 1:
+                march += ext.lower()
+            else:
+                # suffix multiline extensions with '_' 
+                march = march + ext.lower() + '_'
+    
+    # trim final underscore if exists
+    march = march[0:-1] if march[-1] == '_' else march
 
     # mabi generation
     mabi = 'ilp32'

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -179,6 +179,8 @@ def get_march_mabi (isa : str):
     # march generation
 
     march = 'rv32' if '32' in isa else 'rv64'
+    march_list = []
+    march_list.append(march)
 
     # get extension list
     (ext_list, err, err_list) = get_extension_list(isa)
@@ -213,28 +215,25 @@ def get_march_mabi (isa : str):
     # add Zbp and Zbt to null_ext if Zbpbo is present
     if 'Zbpbo' in ext_list:
         null_ext += ['Zbp', 'Zbt']
-
     # construct march
     for ext in ext_list:
         if ext not in null_ext:
+            march_list.append(ext.lower())
             # suffix multicharacter extensions with '_' 
             if len(ext) == 1:
                 march += ext.lower()
             else:
                 # suffix multiline extensions with '_' 
-                march = march + ext.lower() + '_'
-    
-    # trim final underscore if exists
-    march = march[0:-1] if march[-1] == '_' else march
+                march = march + '_' + ext.lower()
 
     # mabi generation
     mabi = 'ilp32'
-    if 'FD' in isa:
+    if 'F' in ext_list and 'D' in ext_list:
         mabi += 'd'
-    elif 'F' in isa:
+    elif 'F' in ext_list:
         mabi += 'f'
     
     if 'rv64' in march:
         mabi = mabi.replace('ilp32', 'lp64')
  
-    return march, mabi
+    return (march, mabi, march_list)

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -170,10 +170,10 @@ def get_march_mabi (isa : str):
         isa:    (string) this is the isa string in canonical order
     
     returns:
-        march:  (string) this is the string to be passed to -march to gcc for a given isa
-        mabi:   (string) this is the string to be passed to -mabi for given isa
-
-        None:   if ISA validation throws error
+        march:      (string) this is the string to be passed to -march to gcc for a given isa
+        mabi:       (string) this is the string to be passed to -mabi for given isa
+        march_list: (list) gives march as a list of all extensions as elements
+        None:       if ISA validation throws error
     '''
 
     # march generation

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -217,7 +217,12 @@ def get_march_mabi (isa : str):
 
     # mabi generation
     mabi = 'ilp32'
+    if 'FD' in isa:
+        mabi += 'd'
+    elif 'F' in isa:
+        mabi += 'f'
+    
     if 'rv64' in march:
-        mabi = 'ilp64d'
+        mabi = mabi.replace('ilp32', 'lp64')
  
     return march, mabi

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -161,4 +161,43 @@ def get_extension_list(isa):
 
     return (extension_list, err, err_list)
 
+def get_march_mabi (isa : str):
+    '''
+    This function returns the corresponding march and mabi argument values
+    for RISC-V GCC
 
+    arguments:
+        isa:    (string) this is the isa string in canonical order
+    
+    returns:
+        march:  (string) this is the string to be passed to -march to gcc for a given isa
+        mabi:   (string) this is the string to be passed to -mabi for given isa
+    '''
+
+    # march generation
+
+    march = isa
+    # remove privilege modes
+    if 'SU' in march:
+        march = march.replace('SU', '')       # remove supervisor
+    elif 'U'in march:
+        march = march.replace('U', '')        # remove user mode
+
+    march = march.lower()
+
+    march = march.replace('smrnmi_', '')    # remove smrnmi
+    march = march.replace('sdext_',  '')    # remove sdext
+    march = march.replace('zicntr_', '')    # remove zicntr
+    march = march.replace('zihpm_',  '')    # remove zihpm
+
+    # remove zbp and zbt if zbpbo is present
+    if 'zbpbo_' in march:
+        march = march.replace('zbp_', '')
+        march = march.replace('zbt_', '')
+
+    # mabi generation
+    mabi = 'ilp32'
+    if 'rv64' in march:
+        mabi = 'ilp64d'
+ 
+    return march, mabi

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -172,18 +172,20 @@ def get_march_mabi (isa : str):
     returns:
         march:  (string) this is the string to be passed to -march to gcc for a given isa
         mabi:   (string) this is the string to be passed to -mabi for given isa
+
+        None:   if ISA validation throws error
     '''
 
     # march generation
 
-    march = isa
-    # remove privilege modes
-    if 'SU' in march:
-        march = march.replace('SU', '')       # remove supervisor
-    elif 'U'in march:
-        march = march.replace('U', '')        # remove user mode
+    march = 'rv32' if '32' in isa else 'rv64'
 
-    march = march.lower()
+    # get extension list
+    (ext_list, err, err_list) = get_extension_list(isa)
+
+    # if isa validation throws errors, return None
+    if err:
+        return None
 
     # extensions to be nullified
     null_ext = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.14.3
+current_version = 3.15.0
 commit = True
 tag = True
 


### PR DESCRIPTION
## Description

This PR adds a function that returns the values for `march` and `mabi` arguments for gcc for a given ISA string. 

### Related Issues

N/A

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [ ] Unratified

### List Extensions

N/A

### Mandatory Checklist:

  - [x] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
