### PR TITLE
Add Zaamo and Zalrsc extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.2] - 2024-01-07
+  - Add Zaamo and Zalrsc extensions
+
 ## [3.16.0] - 2024-01-03
   - use the "hartX" naming for the merged dict
   - improve logging statements

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,4 +1,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.16.0'
+__version__ = '3.16.2'
 

--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -23,7 +23,7 @@ Zve_extensions = [
 Z_extensions = [
         "Zicbom", "Zicbop", "Zicboz", "Zicntr", "Zicsr", "Zicond", "Zicfilp", "Zicfiss", "Zifencei", "Zihintpause", "Zihpm", "Zimop",
         "Zmmul",
-        "Zam", "Zabha", "Zacas",
+        "Zam", "Zaamo", "Zabha", "Zacas", "Zalrsc",
         "Zca", "Zcb", "Zcf", "Zcd" , "Zcmp", "Zcmt", "Zcmop", 
         "Zfh", "Zfa",
         "Zfinx", "Zdinx", "Zhinx", "Zhinxmin",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.16.0
+current_version = 3.16.2
 commit = True
 tag = True
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Zaamo and Zalrsc are A extension components

### Related Issues

> N/A

### Update to/for Ratified/Unratified Extensions 

- [x] Ratified
- [ ] Unratified

### List Extensions

> https://github.com/riscv/riscv-zaamo-zalrsc

### Mandatory Checklist:

  - [X] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [X] Make sure to have created a suitable entry in the CHANGELOG.md.
