### PR TITLE
Add B extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.3] - 2024-01-07
+  - Add B extension
+
 ## [3.16.0] - 2024-01-03
   - use the "hartX" naming for the merged dict
   - improve logging statements

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,4 +1,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.16.0'
+__version__ = '3.16.3'
 

--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -38,4 +38,4 @@ S_extensions = ['Smrnmi','Svnapot','Svadu', 'Sdext']
 sub_extensions = Z_extensions + S_extensions
 
 isa_regex = \
-        re.compile("^RV(32|64|128)[IE][ACDFGHJLMNPQSTUV]*(("+'|'.join(sub_extensions)+")(_("+'|'.join(sub_extensions)+"))*){,1}(X[a-z0-9]*)*(_X[a-z0-9]*)*$")
+        re.compile("^RV(32|64|128)[IE][ABCDFGHJLMNPQSTUV]*(("+'|'.join(sub_extensions)+")(_("+'|'.join(sub_extensions)+"))*){,1}(X[a-z0-9]*)*(_X[a-z0-9]*)*$")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.16.0
+current_version = 3.16.3
 commit = True
 tag = True
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Add unratified B extension. B extension includes Zba, Zbb, and Zbs.

### Related Issues

> N/A

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [X] Unratified

### List Extensions

> https://github.com/riscv/riscv-b

### Mandatory Checklist:

  - [X] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [X] Make sure to have created a suitable entry in the CHANGELOG.md.
