### PR TITLE
Support march generation without custom extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.17.0] - 2024-01-09
+  - support march generation without custom extensions
+
 ## [3.16.0] - 2024-01-03
   - use the "hartX" naming for the merged dict
   - improve logging statements

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,4 +1,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.16.0'
+__version__ = '3.17.0'
 

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -161,7 +161,7 @@ def get_extension_list(isa):
 
     return (extension_list, err, err_list)
 
-def get_march_mabi (isa : str):
+def get_march_mabi (isa : str, opt_remove_custom_exts: bool = False):
     '''
     This function returns the corresponding march and mabi argument values
     for RISC-V GCC
@@ -215,6 +215,13 @@ def get_march_mabi (isa : str):
     # add Zbp and Zbt to null_ext if Zbpbo is present
     if 'Zbpbo' in ext_list:
         null_ext += ['Zbp', 'Zbt']
+
+    # remove all custom extensions
+    for ext in ext_list:
+        if ext.startswith('X'):
+            if opt_remove_custom_exts:
+                ext_list.remove(ext)
+
     # construct march
     for ext in ext_list:
         if ext not in null_ext:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.16.0
+current_version = 3.17.0
 commit = True
 tag = True
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

This PR adds an option to generate march strings without custom extensions.

### Related Issues

#161 

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [x] Unratified

### List Extensions

All custom extensions (X***) will be affected.

### Mandatory Checklist:

  - [x] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
