### PR TITLE
Add ssdbltrp, smdbltrp, sddbltrp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.17.1] - 2024-02-25
+  - add unratified Ssdbltrp, Smdbltrp, and Sddbltrp extensions
+
 ## [3.17.0] - 2024-01-09
   - support march generation without custom extensions
 

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,4 +1,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.17.0'
+__version__ = '3.17.1'
 

--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -33,7 +33,7 @@ Z_extensions = [
         "Zpn", "Zpsf"
 ] + Zve_extensions + Zvl_extensions
 
-S_extensions = ['Smrnmi','Svnapot','Svadu', 'Sdext']
+S_extensions = ['Smrnmi','Smdbltrp', 'Ssdbltrp', 'Svnapot','Svadu', 'Sddbltrp', 'Sdext']
 
 sub_extensions = Z_extensions + S_extensions
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.17.0
+current_version = 3.17.1
 commit = True
 tag = True
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Add Ssdbltrp, Smdbltrp, Sddbltrp extensions

### Related Issues

> N/A

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [X] Unratified

### List Extensions

> https://github.com/riscv/riscv-double-trap

### Mandatory Checklist:

  - [X] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [X] Make sure to have created a suitable entry in the CHANGELOG.md.
