### PR TITLE
mabi generation to account for E extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.18.0] - 2024-04-02
+  - mabi generation to account for E extension
+
 ## [3.17.1] - 2024-02-25
   - add unratified Ssdbltrp, Smdbltrp, and Sddbltrp extensions
 

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,4 +1,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.17.1'
+__version__ = '3.18.0'
 

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -235,6 +235,8 @@ def get_march_mabi (isa : str, opt_remove_custom_exts: bool = False):
 
     # mabi generation
     mabi = 'ilp32'
+    if 'E' in ext_list:
+      mabi += 'e'
     if 'F' in ext_list and 'D' in ext_list:
         mabi += 'd'
     elif 'F' in ext_list:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.17.1
+current_version = 3.18.0
 commit = True
 tag = True
 


### PR DESCRIPTION
## Description

mabi generation function will now include the `e` extension in the mabi string if its present in the input ISA string.

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist.

### Update to/for Ratified/Unratified Extensions 

- [x] Ratified
- [ ] Unratified

### List Extensions

- E (embedded extension)

### Mandatory Checklist:

  - [x] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
