### PR TITLE
mprv should not be implemented when U mode is absent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.18.1] - 2024-04-10
+  - mprv should not be implemented when U mode is absent.
+
 ## [3.18.0] - 2024-04-02
   - mabi generation to account for E extension
 

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,4 +1,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.18.0'
+__version__ = '3.18.1'
 

--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -760,11 +760,11 @@ hart_schema:
                     warl:
                        dependency_fields: []
                        legal:
-                         - mprv[0] in [0x0]
+                         - mprv[0] in [0x0, 0x1]
                        wr_illegal:
                          - unchanged
               default: {implemented: false}
-              check_with: s_check
+              check_with: u_check
             sum:
               type: dict
               schema:
@@ -1175,11 +1175,11 @@ hart_schema:
                     warl:
                        dependency_fields: []
                        legal:
-                         - mprv[0] in [0x0]
+                         - mprv[0] in [0x0, 0x1]
                        wr_illegal:
                          - unchanged
               default: {implemented: false}
-              check_with: s_check
+              check_with: u_check
             sum:
               type: dict
               schema:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.18.0
+current_version = 3.18.1
 commit = True
 tag = True
 


### PR DESCRIPTION
## Description

The current by default disables mprv if S mode is missing. However, as per spec the it should be disabled only if U mode is missing.

### Related Issues

None

### Update to/for Ratified/Unratified Extensions 

- [x] Ratified
- [ ] Unratified

### List Extensions

privilege mode CSR mstatus

### Mandatory Checklist:

  - [x] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
