### PR TITLE
Adding support for the Zalasr unratified extension (https://github.com/riscv/riscv-zalasr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3.19.0] - 2024-05-08
+  - added support for Zalasr unratified extesion
+
 ## [3.18.2] - 2024-04-16
   - added yaml dump_flag which provides for the functions that dump yaml.
 

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,4 +1,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.18.2'
+__version__ = '3.19.0'
 

--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -23,7 +23,7 @@ Zve_extensions = [
 Z_extensions = [
         "Zicbom", "Zicbop", "Zicboz", "Zicntr", "Zicsr", "Zicond", "Zicfilp", "Zicfiss", "Zifencei", "Zihintpause", "Zihpm", "Zimop",
         "Zmmul",
-        "Zam", "Zabha", "Zacas",
+        "Zam", "Zabha", "Zacas", "Zalasr",
         "Zca", "Zcb", "Zcf", "Zcd" , "Zcmp", "Zcmt", "Zcmop", 
         "Zfh", "Zfa",
         "Zfinx", "Zdinx", "Zhinx", "Zhinxmin",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.18.2
+current_version = 3.19.0
 commit = True
 tag = True
 


### PR DESCRIPTION
…m/riscv/riscv-zalasr)

## Description

> Added support for the Zalasr unratified extension (https://github.com/riscv/riscv-zalasr)

### Related Issues

> NA

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [x] Unratified

### List Extensions

> Zalasr (https://github.com/riscv/riscv-zalasr)

### Mandatory Checklist:

  - [x] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
