### PR TITLE
Add Load/Store Pair for RV32 extensions (Zilsd & Zcmlsd)

### DIFF
--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -21,7 +21,7 @@ Zve_extensions = [
 ] + Zvef_extensions + Zved_extensions
 
 Z_extensions = [
-        "Zicbom", "Zicbop", "Zicboz", "Zicntr", "Zicsr", "Zicond", "Zicfilp", "Zicfiss", "Zifencei", "Zihintpause", "Zihpm", "Zimop",
+        "Zicbom", "Zicbop", "Zicboz", "Zicntr", "Zicsr", "Zicond", "Zicfilp", "Zicfiss", "Zifencei", "Zihintpause", "Zihpm", "Zilsd", "Zimop",
         "Zmmul",
         "Zam", "Zabha", "Zacas",
         "Zca", "Zcb", "Zcf", "Zcd" , "Zcmp", "Zcmt", "Zcmop", 

--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -24,7 +24,7 @@ Z_extensions = [
         "Zicbom", "Zicbop", "Zicboz", "Zicntr", "Zicsr", "Zicond", "Zicfilp", "Zicfiss", "Zifencei", "Zihintpause", "Zihpm", "Zilsd", "Zimop",
         "Zmmul",
         "Zam", "Zabha", "Zacas",
-        "Zca", "Zcb", "Zcf", "Zcd" , "Zcmp", "Zcmt", "Zcmop", 
+        "Zca", "Zcb", "Zcf", "Zcd" , "Zcmp", "Zcmt", "Zcmop", "Zcmlsd",
         "Zfh", "Zfa",
         "Zfinx", "Zdinx", "Zhinx", "Zhinxmin",
         "Ztso",

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -82,6 +82,9 @@ def get_extension_list(isa):
     if 'S' in extension_list and not 'U' in extension_list:
         err_list.append( "S cannot exist without U.")
         err = True
+    if 'Zilsd' in extension_list and 'Zcf' in extension_list:
+        err_list.append( "Zilsd includes compressed encodings that are mutually exclusive with Zcf.")
+        err = True        
     if 'Zkn' in extension_list and ( set(['Zbkb', 'Zbkc', 'Zbkx', 'Zkne', 'Zknd', 'Zknh']) & set(extension_list)):
         err_list.append( "Zkn is a superset of Zbkb, Zbkc, Zbkx, Zkne, Zknd, Zknh. In presence of Zkn the subsets must be ignored in the ISA string.")
         err = True

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -82,9 +82,12 @@ def get_extension_list(isa):
     if 'S' in extension_list and not 'U' in extension_list:
         err_list.append( "S cannot exist without U.")
         err = True
-    if 'Zilsd' in extension_list and 'Zcf' in extension_list:
-        err_list.append( "Zilsd includes compressed encodings that are mutually exclusive with Zcf.")
-        err = True        
+    if 'Zcmlsd' in extension_list and 'Zcf' in extension_list:
+        err_list.append( "Zcmlsd encodings are mutually exclusive with Zcf.")
+        err = True
+    if 'Zcmlsd' in extension_list and 'Zilsd' not in extension_list:
+        err_list.append( "Zcmlsd cannot exist without Zilsd.")
+        err = True
     if 'Zkn' in extension_list and ( set(['Zbkb', 'Zbkc', 'Zbkx', 'Zkne', 'Zknd', 'Zknh']) & set(extension_list)):
         err_list.append( "Zkn is a superset of Zbkb, Zbkc, Zbkx, Zkne, Zknd, Zknh. In presence of Zkn the subsets must be ignored in the ISA string.")
         err = True


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

Added Load/Store Pair for RV32 extensions

### Related Issues

N/A

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [x] Unratified

### List Extensions

Zilsd & Zcmlsd: https://github.com/riscv/riscv-zilsd

### Mandatory Checklist:

  - [ ] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [ ] Make sure to have created a suitable entry in the CHANGELOG.md.

Not yet done. Should be done closer to when this is supposed to be merged.
