### PR TITLE
exclude svnapot and fix errors logged from ruamel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3.18.3] - 2024-05-28
+  - exclude Svnapot from march generation. fixes #178.
+  - log raw error messages from ruamel while loading yamls. fixes #179.
+
 ## [3.18.2] - 2024-04-16
   - added yaml dump_flag which provides for the functions that dump yaml.
 

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,4 +1,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.18.2'
+__version__ = '3.18.3'
 

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -210,6 +210,9 @@ def get_march_mabi (isa : str, opt_remove_custom_exts: bool = False):
         'Zbf',
         'Zbm',
         'Zbr',
+
+        # supervisor address translations
+        'Svnapot',
     ]
 
     # add Zbp and Zbt to null_ext if Zbpbo is present

--- a/riscv_config/utils.py
+++ b/riscv_config/utils.py
@@ -45,8 +45,7 @@ def load_yaml(foo, no_anchors=False):
             return yaml.load(file)
     except ruamel.yaml.constructor.DuplicateKeyError as msg:
         logger = logging.getLogger(__name__)
-        error = "\n".join(str(msg).split("\n")[2:-7])
-        logger.error(error)
+        logger.error(msg)
         raise SystemExit
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.18.2
+current_version = 3.18.3
 commit = True
 tag = True
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

1. Svnapot will be excluded from the list of extensions used for march generation.
2. load_yaml will log raw error messages from ruamel.

### Related Issues

#178 and #179

### Update to/for Ratified/Unratified Extensions 

- [x] Ratified
- [ ] Unratified

### List Extensions

1. Svnapot - Standard Extension for NAPOT Translation Contiguity

### Mandatory Checklist:

  - [x] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
