### PR TITLE
isa_string variable in debug spec now depends on the hartid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.18.4] - 2024-06-01
+  - isa\_string variable in debug spec now depends on the hartid (instead of always depending on
+    `hart0`)
+
 ## [3.18.3] - 2024-05-28
   - exclude Svnapot from march generation. fixes #178.
   - log raw error messages from ruamel while loading yamls. fixes #179.

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,4 +1,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.18.3'
+__version__ = '3.18.4'
 

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -1746,7 +1746,6 @@ def check_debug_specs(debug_spec, isa_spec,
     if logging:
         logger.info('DebugCheck: Loading input isa file for debug: ' + str(foo1))
     master_inp_yaml = utils.load_yaml(foo1, no_anchors)
-    isa_string = master_inp_yaml['hart0']['ISA']
 
     # instantiate validator
     if logging:
@@ -1755,6 +1754,7 @@ def check_debug_specs(debug_spec, isa_spec,
 
     outyaml = copy.deepcopy(master_inp_debug_yaml)
     for x in master_inp_debug_yaml['hart_ids']:
+        isa_string = master_inp_yaml[f'hart{x}']['ISA']
         if logging:
             logger.info(f'DebugCheck: Processing Hart:{x}')
         inp_debug_yaml = master_inp_debug_yaml['hart'+str(x)]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.18.3
+current_version = 3.18.4
 commit = True
 tag = True
 


### PR DESCRIPTION
## Description

The isa\_string variable when performing debug checks always assumed the existence of hartid `0`. This hardwiring has been removed.

### Related Issues

NA

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Mandatory Checklist:

  - [x] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
