### PR TITLE
Add Sdtrig extension.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.20.0] - 2024-07-08
+  - Add Sdtrig support
+
 ## [3.19.0] - 2024-06-07 (WIP)
   - added support for Zalasr unratified extesion
   - isa\_string variable in debug spec now depends on the hartid (instead of always depending on

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.19.0'
+__version__ = '3.20.0'

--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -33,7 +33,7 @@ Z_extensions = [
         "Zpn", "Zpsf"
 ] + Zve_extensions + Zvl_extensions
 
-S_extensions = ['Smrnmi','Smdbltrp', 'Ssdbltrp', 'Svnapot','Svadu', 'Sddbltrp', 'Sdext']
+S_extensions = ['Smrnmi','Smdbltrp', 'Ssdbltrp', 'Svnapot','Svadu', 'Sddbltrp', 'Sdext', 'Sdtrig']
 
 sub_extensions = Z_extensions + S_extensions
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.19.0
+current_version = 3.20.0
 commit = True
 tag = True
 


### PR DESCRIPTION
I need this for ACT support, because otherwise riscof fails to run altogether.

<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

Add Sdtrig to list of S extensions.

### Related Issues

NA

### Update to/for Ratified/Unratified Extensions 

Unratified

### List Extensions

Sdtrig

### Mandatory Checklist:

  - [x] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
