### PR TITLE
Improve error message when regex doesn't match.

### DIFF
--- a/riscv_config/schemaValidator.py
+++ b/riscv_config/schemaValidator.py
@@ -110,7 +110,8 @@ class schemaValidator(Validator):
             self._error(field, "Invalid width in ISA.")
 
         if not constants.isa_regex.match(value):
-            self._error(field, 'Input ISA string does not match regex')
+            self._error(field, 'Input ISA string %r does not match regex from %s' % (
+                value, constants.__file__))
         if ext_err:
             for e in ext_err_list:
                 self._error(field, e)


### PR DESCRIPTION
## Description

Point the user at the source of the regex. This would have saved me time when encountering the error in `riscof` which gave me no indication of what the actual problem was.

### Related Issues

NA

### Update to/for Ratified/Unratified Extensions 

NA

### List Extensions

NA

### Mandatory Checklist:

I don't know how to deal with version numbers when there are multiple PRs outstanding.

  - [ ] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [ ] Make sure to have created a suitable entry in the CHANGELOG.md.
