### PR TITLE
change the address for mstatush to 784 (issue #185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.20.0] - 2024-07-08
+## [3.19.0] - 2024-08-23 (WIP)
+  - change the address for mstatush to 784 (issue #185)
   - Add Sdtrig support
-
-## [3.19.0] - 2024-06-07 (WIP)
   - added support for Zalasr unratified extesion
   - isa\_string variable in debug spec now depends on the hartid (instead of always depending on
     `hart0`)

--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -1470,7 +1470,7 @@ hart_schema:
           type: string
           default: The mstatush register keeps track of and controls the hart's current
             operating state.
-        address: {type: integer, default: 768, allowed: [768]}
+        address: {type: integer, default: 784, allowed: [784]}
         priv_mode: {type: string, default: M, allowed: [M]}
         reset-val:
           type: integer


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

change the address for mstatush to 784

### Related Issues

#185 

### Update to/for Ratified/Unratified Extensions 

- [x] Ratified
- [ ] Unratified

### List Extensions

- privilege spec

### Mandatory Checklist:

  - [ ] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
