### PR TITLE
Updating Load/Store Pair for RV32 to version 0.10

### DIFF
--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -24,7 +24,7 @@ Z_extensions = [
         "Zicbom", "Zicbop", "Zicboz", "Zicntr", "Zicsr", "Zicond", "Zicfilp", "Zicfiss", "Zifencei", "Zihintpause", "Zihpm", "Zilsd", "Zimop",
         "Zmmul",
         "Zam", "Zabha", "Zacas", "Zalasr",
-        "Zca", "Zcb", "Zcf", "Zcd" , "Zcmp", "Zcmt", "Zcmop", "Zcmlsd",
+        "Zca", "Zcb", "Zcf", "Zcd" , "Zcmp", "Zcmt", "Zcmop", "Zclsd",
         "Zfh", "Zfa",
         "Zfinx", "Zdinx", "Zhinx", "Zhinxmin",
         "Ztso",

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -82,11 +82,11 @@ def get_extension_list(isa):
     if 'S' in extension_list and not 'U' in extension_list:
         err_list.append( "S cannot exist without U.")
         err = True
-    if 'Zcmlsd' in extension_list and 'Zcf' in extension_list:
-        err_list.append( "Zcmlsd encodings are mutually exclusive with Zcf.")
+    if 'Zclsd' in extension_list and 'Zcf' in extension_list:
+        err_list.append( "Zclsd encodings are mutually exclusive with Zcf.")
         err = True
-    if 'Zcmlsd' in extension_list and 'Zilsd' not in extension_list:
-        err_list.append( "Zcmlsd cannot exist without Zilsd.")
+    if 'Zclsd' in extension_list and 'Zilsd' not in extension_list:
+        err_list.append( "Zclsd cannot exist without Zilsd.")
         err = True
     if 'Zkn' in extension_list and ( set(['Zbkb', 'Zbkc', 'Zbkx', 'Zkne', 'Zknd', 'Zknh']) & set(extension_list)):
         err_list.append( "Zkn is a superset of Zbkb, Zbkc, Zbkx, Zkne, Zknd, Zknh. In presence of Zkn the subsets must be ignored in the ISA string.")


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

Updated from Load/Store pair version 0.9 to version 0.19.
Changed name of compressed extension from Zcmlsd to Zclsd

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist.

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [ x] Unratified

### List Extensions

Zclsd https://github.com/riscv/riscv-zilsd/releases/tag/v0.10

### Mandatory Checklist:

  - [ ] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [ ] Make sure to have created a suitable entry in the CHANGELOG.md.
