### PR TITLE
fix: Zvl512b Mislabelled as Zve512b

### DIFF
--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -8,7 +8,7 @@ debug_schema = os.path.join(root, 'schemas/schema_debug.yaml')
 platform_schema = os.path.join(root, 'schemas/schema_platform.yaml')
 custom_schema = os.path.join(root, 'schemas/schema_custom.yaml')
 Zvl_extensions = [
-        "Zvl32b", "Zvl64b", "Zvl128b", "Zvl256b", "Zve512b", "Zvl1024b"
+        "Zvl32b", "Zvl64b", "Zvl128b", "Zvl256b", "Zvl512b", "Zvl1024b"
 ]
 Zvef_extensions = [
         "Zve32f", "Zve64f"


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Zvl512b is mistakenly written as Zve512b in Zvl_extensions. Fix typo.

### Related Issues

> #187 

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Mandatory Checklist:

  - [ ] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [ ] Make sure to have created a suitable entry in the CHANGELOG.md.
