### PR TITLE
fix: Zk extension String Causes 'String Index Out of Range' Error

### DIFF
--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -52,14 +52,19 @@ def get_extension_list(isa):
     for i in range(len(zext_list)-1):
         a1 = zext_list[i][1].upper()
         a2 = zext_list[i+1][1].upper()
-        a3 = zext_list[i][2]
-        a4 = zext_list[i+1][2]
         if order_index[a1] > order_index[a2]:
             err = True
             err_list.append( f"Z extension {zext_list[i]} must occur after {zext_list[i+1]}")
-        elif a1 == a2 and a3 > a4:
-            err = True
-            err_list.append( f"Within the Z{a1.lower()} category extension {zext_list[i]} must occur after {zext_list[i+1]}")
+        elif a1 == a2:
+            if (len(zext_list[i]) > 2) and (len(zext_list[i]) == 2):
+                err = True
+                err_list.append( f"Within the Z{a1.lower()} category extension {zext_list[i]} must occur after {zext_list[i+1]}")
+            elif (len(zext_list[i]) > 2) and (len(zext_list[i]) > 2):
+                a3 = zext_list[i][2]
+                a4 = zext_list[i+1][2]
+                if a3 > a4:
+                    err = True
+                    err_list.append( f"Within the Z{a1.lower()} category extension {zext_list[i]} must occur after {zext_list[i+1]}")
         
     if 'I' not in extension_list and 'E' not in extension_list:
         err_list.append( 'Either of I or E base extensions need to be present in the ISA string')


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Zk extension String Causes 'String Index Out of Range' Error. fix it.

### Related Issues

> #186 

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Mandatory Checklist:

  - [ ] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [ ] Make sure to have created a suitable entry in the CHANGELOG.md.
