### PR TITLE
Update zcmlsd to zclsd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.21.0] - 2025-03-27
+  - Rename zcmlsd to zclas
+
 ## [3.20.0] - 2024-07-08
   - Add Sdtrig support
 

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.20.0'
+__version__ = '3.21.0'

--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -24,7 +24,7 @@ Z_extensions = [
         "Zicbom", "Zicbop", "Zicboz", "Zicntr", "Zicsr", "Zicond", "Zicfilp", "Zicfiss", "Zifencei", "Zihintpause", "Zihpm", "Zilsd", "Zimop",
         "Zmmul",
         "Zam", "Zabha", "Zacas", "Zalasr",
-        "Zca", "Zcb", "Zcf", "Zcd" , "Zcmp", "Zcmt", "Zcmop", "Zcmlsd",
+        "Zca", "Zcb", "Zcf", "Zcd" , "Zcmp", "Zcmt", "Zcmop", "Zclsd",
         "Zfh", "Zfa",
         "Zfinx", "Zdinx", "Zhinx", "Zhinxmin",
         "Ztso",

--- a/riscv_config/isa_validator.py
+++ b/riscv_config/isa_validator.py
@@ -82,11 +82,11 @@ def get_extension_list(isa):
     if 'S' in extension_list and not 'U' in extension_list:
         err_list.append( "S cannot exist without U.")
         err = True
-    if 'Zcmlsd' in extension_list and 'Zcf' in extension_list:
-        err_list.append( "Zcmlsd encodings are mutually exclusive with Zcf.")
+    if 'Zclsd' in extension_list and 'Zcf' in extension_list:
+        err_list.append( "Zclsd encodings are mutually exclusive with Zcf.")
         err = True
-    if 'Zcmlsd' in extension_list and 'Zilsd' not in extension_list:
-        err_list.append( "Zcmlsd cannot exist without Zilsd.")
+    if 'Zclsd' in extension_list and 'Zilsd' not in extension_list:
+        err_list.append( "Zclsd cannot exist without Zilsd.")
         err = True
     if 'Zkn' in extension_list and ( set(['Zbkb', 'Zbkc', 'Zbkx', 'Zkne', 'Zknd', 'Zknh']) & set(extension_list)):
         err_list.append( "Zkn is a superset of Zbkb, Zbkc, Zbkx, Zkne, Zknd, Zknh. In presence of Zkn the subsets must be ignored in the ISA string.")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.20.0
+current_version = 3.21.0
 commit = True
 tag = True
 


### PR DESCRIPTION
## Description

Just a rename

### Related Issues

https://github.com/riscv/riscv-zilsd/pull/42

### Update to/for Ratified/Unratified Extensions 

- [x] Ratified
- [ ] Unratified

### List Extensions

- Zclsd

### Mandatory Checklist:

  - [x] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [x] Make sure to have created a suitable entry in the CHANGELOG.md.
