### PR TITLE
Remove tab space for pmp-writable schema

### DIFF
--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -153,7 +153,7 @@ hart_schema:
           type: integer
           max: [64]
           default: 16
-	pmp-writable:
+        pmp-writable:
           type: integer
           max: [64]
           default: 7


### PR DESCRIPTION
This commit removes the tab space before the pmp-writable entry.