### PR TITLE
Permit underscores after single-letter extensions

### DIFF
--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -38,4 +38,4 @@ S_extensions = ['Smrnmi','Smdbltrp', 'Ssdbltrp', 'Svnapot','Svadu', 'Sddbltrp', 
 sub_extensions = Z_extensions + S_extensions
 
 isa_regex = \
-        re.compile("^RV(32|64|128)[IE][ACDFGHJLMNPQSTUV]*(("+'|'.join(sub_extensions)+")(_("+'|'.join(sub_extensions)+"))*){,1}(X[a-z0-9]*)*(_X[a-z0-9]*)*$")
+        re.compile("^RV(32|64|128)[IE]_?(?:[ACDFGHJLMNPQSTUV]_?)*(("+'|'.join(sub_extensions)+")(_("+'|'.join(sub_extensions)+"))*){,1}(X[a-z0-9]*)*(_X[a-z0-9]*)*$")


### PR DESCRIPTION
The spec permits optional underscores between single-letter extensions, and before the first Z extension. Reference is here: https://github.com/riscv/riscv-isa-manual/blob/main/src/naming.adoc#underscores

However the regex used in `riscv-config` rejects these underscores. This was raised already in #151. This patch updates the regex to permit underscores in these locations.