### PR TITLE
Fixed typo in constants.py

### DIFF
--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -8,7 +8,7 @@ debug_schema = os.path.join(root, 'schemas/schema_debug.yaml')
 platform_schema = os.path.join(root, 'schemas/schema_platform.yaml')
 custom_schema = os.path.join(root, 'schemas/schema_custom.yaml')
 Zvl_extensions = [
-        "Zvl32b", "Zvl64b", "Zvl128b", "Zvl256b", "Zve512b", "Zvl1024b"
+        "Zvl32b", "Zvl64b", "Zvl128b", "Zvl256b", "Zvl512b", "Zvl1024b"
 ]
 Zvef_extensions = [
         "Zve32f", "Zve64f"

--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -8,7 +8,7 @@ debug_schema = os.path.join(root, 'schemas/schema_debug.yaml')
 platform_schema = os.path.join(root, 'schemas/schema_platform.yaml')
 custom_schema = os.path.join(root, 'schemas/schema_custom.yaml')
 Zvl_extensions = [
-        "Zvl32b", "Zvl64b", "Zvl128b", "Zvl256b", "Zvl512b", "Zvl1024b", "Zvl2048b"
+        "Zvl32b", "Zvl64b", "Zvl128b", "Zvl256b", "Zvl512b", "Zvl1024b", "Zvl2048b", "Zvl4096b"
 ]
 Zvef_extensions = [
         "Zve32f", "Zve64f"

--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -8,7 +8,7 @@ debug_schema = os.path.join(root, 'schemas/schema_debug.yaml')
 platform_schema = os.path.join(root, 'schemas/schema_platform.yaml')
 custom_schema = os.path.join(root, 'schemas/schema_custom.yaml')
 Zvl_extensions = [
-        "Zvl32b", "Zvl64b", "Zvl128b", "Zvl256b", "Zvl512b", "Zvl1024b"
+        "Zvl32b", "Zvl64b", "Zvl128b", "Zvl256b", "Zvl512b", "Zvl1024b", "Zvl2048b"
 ]
 Zvef_extensions = [
         "Zve32f", "Zve64f"


### PR DESCRIPTION
Fixed typo of `Zve512b` to `Zvl512b` in `Zvl_extensions`.
