### PR TITLE
Add unratified Ziccid extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.18.4] - 2026-01-19
+  - Add unratified Ziccid extension
+
 ## [3.18.3] - 2024-05-28
   - exclude Svnapot from march generation. fixes #178.
   - log raw error messages from ruamel while loading yamls. fixes #179.

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,4 +1,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '3.18.3'
+__version__ = '3.18.4'
 

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,4 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-
 __version__ = '3.21.0'

--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -30,7 +30,8 @@ Z_extensions = [
         "Ztso",
         "Zba", "Zbb", "Zbc", "Zbe", "Zbf", "Zbkb", "Zbkc", "Zbkx", "Zbm", "Zbp", "Zbpbo", "Zbr", "Zbs", "Zbt",
         "Zk", "Zkn", "Zknd", "Zkne", "Zknh", "Zkr", "Zks", "Zksed", "Zksh", "Zkt",
-        "Zpn", "Zpsf"
+        "Zpn", "Zpsf",
+        "Ziccid"
 ] + Zve_extensions + Zvl_extensions
 
 S_extensions = ['Smrnmi','Smdbltrp', 'Ssdbltrp', 'Svnapot','Svadu', 'Sddbltrp', 'Sdext']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.18.3
+current_version = 3.18.4
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [bumpversion]
 current_version = 3.21.0
-
 commit = True
 tag = True
 


### PR DESCRIPTION
## Description

Adds configuration for unratified Ziccid extension

### Related Issues

NA

### Update to/for Ratified/Unratified Extensions 

- [ ] Ratified
- [X] Unratified

### List Extensions

https://github.com/aswaterman/riscv-misc/blob/main/isa/ziccid.adoc

### Mandatory Checklist:

  - [X] Make sure you have updated the versions in `setup.cfg` and `riscv_config/__init__.py`. Refer to CONTRIBUTING.rst file for further information.
  - [X] Make sure to have created a suitable entry in the CHANGELOG.md.
